### PR TITLE
Add employee management dashboard and clean testimonials

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -50,3 +50,23 @@ alter table public.employees enable row level security;
 create index if not exists employees_status_idx on public.employees (status);
 create index if not exists employees_last_name_idx on public.employees (last_name);
 
+-- Access control for Identity accounts (admins, employees, clients)
+create table if not exists public.access_grants (
+  id uuid primary key default uuid_generate_v4(),
+  email text not null unique,
+  name text,
+  role text not null default 'client', -- admin | employee | client
+  status text not null default 'active', -- active | suspended
+  notes text,
+  last_seen_at timestamptz,
+  last_seen_ip text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.access_grants enable row level security;
+
+create index if not exists access_grants_email_idx on public.access_grants (email);
+create index if not exists access_grants_role_idx on public.access_grants (role);
+create index if not exists access_grants_status_idx on public.access_grants (status);
+

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -29,3 +29,24 @@ alter table public.quotes add column if not exists "processedAt" timestamptz;
 alter table public.quotes add column if not exists assignee text;
 create index if not exists quotes_status_idx on public.quotes (status);
 
+-- Employees directory for internal operations
+create table if not exists public.employees (
+  id uuid primary key default uuid_generate_v4(),
+  first_name text not null,
+  last_name text not null,
+  email text not null,
+  role text not null,
+  phone text,
+  start_date date,
+  status text not null default 'active', -- active | on_leave | former
+  hourly_rate numeric,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.employees enable row level security;
+
+create index if not exists employees_status_idx on public.employees (status);
+create index if not exists employees_last_name_idx on public.employees (last_name);
+

--- a/netlify/functions/_auth.js
+++ b/netlify/functions/_auth.js
@@ -1,14 +1,12 @@
 const crypto = require('crypto')
 
+const ACCESS_ROLES = ['admin', 'employee', 'client']
+
 function b64urlDecode(s) {
   s = s.replace(/-/g, '+').replace(/_/g, '/')
   const pad = s.length % 4
   if (pad) s += '='.repeat(4 - pad)
   return Buffer.from(s, 'base64')
-}
-
-function b64urlEncode(buf) {
-  return Buffer.from(buf).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
 }
 
 function deriveKey(secret) {
@@ -41,7 +39,58 @@ function getClientIp(event) {
   ).split(',')[0].trim()
 }
 
-function verifyAdminToken(event, options = {}) {
+function getIdentityBaseUrl(event) {
+  const fromEnv = process.env.IDENTITY_URL || process.env.IDENTITY_INSTANCE_URL
+  if (fromEnv) return fromEnv.replace(/\/$/, '')
+  const proto = event.headers['x-forwarded-proto'] || 'https'
+  const host = event.headers['x-forwarded-host'] || event.headers['host']
+  if (!host) throw new Error('Identity service unavailable')
+  return `${proto}://${host}/.netlify/identity`
+}
+
+async function verifyIdentityToken(event) {
+  const auth = event.headers.authorization || event.headers.Authorization
+  if (!auth || !auth.toLowerCase().startsWith('bearer ')) {
+    throw new Error('Missing identity token')
+  }
+  const token = auth.slice(auth.indexOf(' ') + 1).trim()
+  if (!token) throw new Error('Missing identity token')
+  const baseUrl = getIdentityBaseUrl(event)
+  const res = await fetch(`${baseUrl}/user`, {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(detail || 'Invalid identity token')
+  }
+  const data = await res.json()
+  const email = String(data.email || '').toLowerCase()
+  if (!email) throw new Error('Identity email missing')
+  return { token, user: data, email }
+}
+
+function getAdminEmails() {
+  const raw = process.env.ADMIN_EMAILS || ''
+  return raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+function getOwnerEmails() {
+  const raw = process.env.IDENTITY_OWNER_EMAILS || process.env.OWNER_EMAILS || process.env.ADMIN_EMAILS || ''
+  const defaults = ['vetwrapinc@gmail.com']
+  const list = raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+  defaults.forEach((email) => {
+    if (!list.includes(email)) list.push(email)
+  })
+  return list
+}
+
+function verifyAdminToken(event) {
   const header = event.headers['x-admin-token'] || event.headers['X-Admin-Token']
   const secret = process.env.ADMIN_TOKEN_SECRET
   if (!secret) throw new Error('Admin token not configured')
@@ -51,15 +100,152 @@ function verifyAdminToken(event, options = {}) {
   if (typeof payload.exp !== 'number' || payload.exp < now) throw new Error('Token expired')
   const ip = getClientIp(event)
   if (!ip || payload.ip !== ip) throw new Error('IP mismatch')
-  const admins = (process.env.ADMIN_EMAILS || '').toLowerCase().split(',').map(s => s.trim()).filter(Boolean)
+  const admins = getAdminEmails()
   const email = String(payload.email || '').toLowerCase()
   if (!admins.includes(email)) throw new Error('Not authorized')
   return { email, ip, payload }
+}
+
+function getSupabaseConfig(tableEnv, fallbackTable) {
+  const url = process.env.SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE
+  const table = process.env[tableEnv] || fallbackTable
+  if (!url || !key || !table) throw new Error('Supabase not configured')
+  return { url, key, table }
+}
+
+async function fetchAccessGrant(email) {
+  if (!email) return null
+  let config
+  try {
+    config = getSupabaseConfig('SUPABASE_ACCESS_TABLE', 'access_grants')
+  } catch (err) {
+    return null
+  }
+  const { url, key, table } = config
+  const res = await fetch(
+    `${url}/rest/v1/${table}?email=eq.${encodeURIComponent(email)}&limit=1`,
+    {
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`
+      }
+    }
+  )
+  if (!res.ok) {
+    throw new Error('Supabase access lookup failed')
+  }
+  const data = await res.json()
+  if (!Array.isArray(data) || data.length === 0) return null
+  return data[0]
+}
+
+async function touchAccessGrant(id, patch) {
+  if (!id) return
+  let config
+  try {
+    config = getSupabaseConfig('SUPABASE_ACCESS_TABLE', 'access_grants')
+  } catch (err) {
+    return
+  }
+  const { url, key, table } = config
+  await fetch(`${url}/rest/v1/${table}?id=eq.${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+      Prefer: 'resolution=merge-duplicates'
+    },
+    body: JSON.stringify(patch)
+  }).catch(() => {})
+}
+
+async function requireAccess(event, options = {}) {
+  const allowRoles = Array.isArray(options.allow) ? options.allow : []
+  const allowSuspended = Boolean(options.allowSuspended)
+  const requireAdmin = Boolean(options.requireAdmin)
+
+  try {
+    const admin = verifyAdminToken(event)
+    return {
+      type: 'admin-token',
+      email: admin.email,
+      role: 'admin',
+      isAdmin: true,
+      grant: { email: admin.email, role: 'admin', status: 'active' }
+    }
+  } catch (err) {
+    // continue to identity flow
+  }
+
+  const identity = await verifyIdentityToken(event)
+  const email = identity.email
+  let grant = null
+  try {
+    grant = await fetchAccessGrant(email)
+  } catch (err) {
+    throw err
+  }
+
+  const ownerEmails = getOwnerEmails()
+  if (!grant && ownerEmails.includes(email)) {
+    grant = {
+      email,
+      role: 'admin',
+      status: 'active'
+    }
+  }
+
+  if (!grant) {
+    throw new Error('Account not authorized')
+  }
+
+  const role = String(grant.role || '').toLowerCase()
+  const normalizedRole = ACCESS_ROLES.includes(role) ? role : 'client'
+  const status = String(grant.status || '').toLowerCase() || 'active'
+
+  if (!allowSuspended && status !== 'active') {
+    throw new Error('Account suspended')
+  }
+  if (requireAdmin && normalizedRole !== 'admin') {
+    throw new Error('Admin privileges required')
+  }
+  if (allowRoles.length > 0 && !allowRoles.includes(normalizedRole)) {
+    throw new Error('Access denied')
+  }
+
+  const now = new Date().toISOString()
+  const ip = getClientIp(event) || null
+  touchAccessGrant(grant.id, {
+    last_seen_at: now,
+    last_seen_ip: ip,
+    updated_at: now
+  }).catch(() => {})
+
+  return {
+    type: 'identity',
+    email,
+    role: normalizedRole,
+    isAdmin: normalizedRole === 'admin',
+    grant: { ...grant, role: normalizedRole, status }
+  }
 }
 
 function json(statusCode, data) {
   return { statusCode, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) }
 }
 
-module.exports = { verifyAdminToken, json, getClientIp }
+module.exports = {
+  verifyAdminToken,
+  verifyIdentityToken,
+  fetchAccessGrant,
+  requireAccess,
+  json,
+  getClientIp,
+  touchAccessGrant,
+  ACCESS_ROLES,
+  getOwnerEmails,
+  getSupabaseConfig
+}
 

--- a/netlify/functions/access-grants-delete.js
+++ b/netlify/functions/access-grants-delete.js
@@ -1,13 +1,14 @@
-const { requireAccess, json } = require('./_auth')
+const { requireAccess, json, getSupabaseConfig } = require('./_auth')
 
 exports.handler = async (event) => {
   if (!['POST', 'DELETE'].includes(event.httpMethod)) {
     return json(405, { error: 'Method Not Allowed' })
   }
+
   try {
     await requireAccess(event, { allow: ['admin'] })
-  } catch (e) {
-    return json(401, { error: e.message || 'Unauthorized' })
+  } catch (err) {
+    return json(401, { error: err.message || 'Unauthorized' })
   }
 
   let id
@@ -15,24 +16,26 @@ exports.handler = async (event) => {
     id = event.queryStringParameters?.id
   } else {
     try {
-      const body = JSON.parse(event.body || '{}')
-      id = body.id
+      const payload = JSON.parse(event.body || '{}')
+      id = payload.id
     } catch (err) {
       return json(400, { error: 'Invalid JSON' })
     }
   }
 
+  if (id) id = String(id).trim()
   if (!id) {
     return json(400, { error: 'Missing id' })
   }
 
-  const url = process.env.SUPABASE_URL
-  const key = process.env.SUPABASE_SERVICE_ROLE
-  const table = process.env.SUPABASE_EMPLOYEES_TABLE || 'employees'
-  if (!url || !key) {
-    return json(500, { error: 'Supabase not configured' })
+  let config
+  try {
+    config = getSupabaseConfig('SUPABASE_ACCESS_TABLE', 'access_grants')
+  } catch (err) {
+    return json(500, { error: err.message || 'Access store unavailable' })
   }
 
+  const { url, key, table } = config
   const res = await fetch(`${url}/rest/v1/${table}?id=eq.${encodeURIComponent(id)}`, {
     method: 'DELETE',
     headers: {

--- a/netlify/functions/access-grants-list.js
+++ b/netlify/functions/access-grants-list.js
@@ -1,0 +1,41 @@
+const { requireAccess, json, getSupabaseConfig } = require('./_auth')
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'GET') {
+    return json(405, { error: 'Method Not Allowed' })
+  }
+
+  try {
+    await requireAccess(event, { allow: ['admin'] })
+  } catch (err) {
+    return json(401, { error: err.message || 'Unauthorized' })
+  }
+
+  let config
+  try {
+    config = getSupabaseConfig('SUPABASE_ACCESS_TABLE', 'access_grants')
+  } catch (err) {
+    return json(500, { error: err.message || 'Access store unavailable' })
+  }
+
+  const { url, key, table } = config
+  const params = new URLSearchParams({ select: '*', order: 'updated_at.desc' })
+  const qs = event.queryStringParameters || {}
+  if (qs.status) params.append('status', `eq.${String(qs.status).toLowerCase()}`)
+  if (qs.role) params.append('role', `eq.${String(qs.role).toLowerCase()}`)
+
+  const res = await fetch(`${url}/rest/v1/${table}?${params.toString()}`, {
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`
+    }
+  })
+
+  if (!res.ok) {
+    const detail = await res.text()
+    return json(502, { error: 'Supabase error', detail })
+  }
+
+  const data = await res.json()
+  return json(200, { items: Array.isArray(data) ? data : [] })
+}

--- a/netlify/functions/access-grants-save.js
+++ b/netlify/functions/access-grants-save.js
@@ -1,0 +1,91 @@
+const { requireAccess, json, ACCESS_ROLES, getSupabaseConfig } = require('./_auth')
+
+const allowedStatuses = new Set(['active', 'suspended'])
+
+function sanitize(value, max = 160) {
+  if (value === undefined || value === null) return null
+  const trimmed = String(value).trim()
+  if (!trimmed) return null
+  return trimmed.slice(0, max)
+}
+
+exports.handler = async (event) => {
+  if (!['POST', 'PUT', 'PATCH'].includes(event.httpMethod)) {
+    return json(405, { error: 'Method Not Allowed' })
+  }
+
+  try {
+    await requireAccess(event, { allow: ['admin'] })
+  } catch (err) {
+    return json(401, { error: err.message || 'Unauthorized' })
+  }
+
+  let payload
+  try {
+    payload = JSON.parse(event.body || '{}')
+  } catch (err) {
+    return json(400, { error: 'Invalid JSON' })
+  }
+
+  const id = sanitize(payload.id, 80)
+  const email = sanitize(payload.email, 200)?.toLowerCase()
+  if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+    return json(400, { error: 'Valid email required' })
+  }
+
+  const role = (sanitize(payload.role, 40) || 'client').toLowerCase()
+  if (!ACCESS_ROLES.includes(role)) {
+    return json(400, { error: 'Invalid role' })
+  }
+
+  const status = (sanitize(payload.status, 40) || 'active').toLowerCase()
+  if (!allowedStatuses.has(status)) {
+    return json(400, { error: 'Invalid status' })
+  }
+
+  const now = new Date().toISOString()
+  const record = {
+    email,
+    name: sanitize(payload.name, 160),
+    role,
+    status,
+    notes: sanitize(payload.notes, 2000),
+    updated_at: now
+  }
+  if (!id) {
+    record.created_at = now
+  }
+
+  let config
+  try {
+    config = getSupabaseConfig('SUPABASE_ACCESS_TABLE', 'access_grants')
+  } catch (err) {
+    return json(500, { error: err.message || 'Access store unavailable' })
+  }
+
+  const { url, key, table } = config
+  const method = id ? 'PATCH' : 'POST'
+  const endpoint = id
+    ? `${url}/rest/v1/${table}?id=eq.${encodeURIComponent(id)}`
+    : `${url}/rest/v1/${table}`
+
+  const res = await fetch(endpoint, {
+    method,
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation'
+    },
+    body: JSON.stringify(record)
+  })
+
+  if (!res.ok) {
+    const detail = await res.text()
+    return json(502, { error: 'Supabase error', detail })
+  }
+
+  const data = await res.json()
+  const item = Array.isArray(data) ? data[0] : data
+  return json(200, { ok: true, item })
+}

--- a/netlify/functions/access-session.js
+++ b/netlify/functions/access-session.js
@@ -1,0 +1,90 @@
+const {
+  verifyAdminToken,
+  verifyIdentityToken,
+  fetchAccessGrant,
+  touchAccessGrant,
+  getClientIp,
+  getOwnerEmails,
+  json
+} = require('./_auth')
+
+function normalizeGrant(grant) {
+  if (!grant) return null
+  const role = String(grant.role || 'client').toLowerCase()
+  const status = String(grant.status || 'active').toLowerCase()
+  return { ...grant, role, status }
+}
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'GET') {
+    return json(405, { error: 'Method Not Allowed' })
+  }
+
+  try {
+    const admin = verifyAdminToken(event)
+    return json(200, {
+      allowed: true,
+      via: 'token',
+      grant: {
+        email: admin.email,
+        role: 'admin',
+        status: 'active'
+      }
+    })
+  } catch (err) {
+    // continue with identity flow
+  }
+
+  let identity
+  try {
+    identity = await verifyIdentityToken(event)
+  } catch (err) {
+    return json(401, { error: err.message || 'Unauthorized' })
+  }
+
+  let grant = null
+  try {
+    grant = await fetchAccessGrant(identity.email)
+  } catch (err) {
+    return json(500, { error: err.message || 'Access lookup failed' })
+  }
+
+  if (!grant) {
+    const owners = getOwnerEmails()
+    if (owners.includes(identity.email)) {
+      grant = {
+        email: identity.email,
+        role: 'admin',
+        status: 'active',
+        name:
+          identity.user?.user_metadata?.full_name ||
+          identity.user?.full_name ||
+          identity.user?.name ||
+          null
+      }
+    }
+  }
+
+  const normalized = normalizeGrant(grant)
+  if (!normalized) {
+    return json(200, { allowed: false, grant: null, reason: 'Account not authorized' })
+  }
+
+  const allowed = normalized.status === 'active'
+  const response = {
+    allowed,
+    grant: normalized,
+    reason: allowed ? '' : 'Account suspended'
+  }
+
+  if (allowed) {
+    const now = new Date().toISOString()
+    touchAccessGrant(normalized.id, {
+      last_seen_at: now,
+      last_seen_ip: getClientIp(event) || null,
+      updated_at: now
+    }).catch(() => {})
+  }
+
+  return json(200, response)
+}

--- a/netlify/functions/employees-delete.js
+++ b/netlify/functions/employees-delete.js
@@ -1,0 +1,51 @@
+const { verifyAdminToken, json } = require('./_auth')
+
+exports.handler = async (event) => {
+  if (!['POST', 'DELETE'].includes(event.httpMethod)) {
+    return json(405, { error: 'Method Not Allowed' })
+  }
+  try {
+    verifyAdminToken(event)
+  } catch (e) {
+    return json(401, { error: e.message || 'Unauthorized' })
+  }
+
+  let id
+  if (event.httpMethod === 'DELETE') {
+    id = event.queryStringParameters?.id
+  } else {
+    try {
+      const body = JSON.parse(event.body || '{}')
+      id = body.id
+    } catch (err) {
+      return json(400, { error: 'Invalid JSON' })
+    }
+  }
+
+  if (!id) {
+    return json(400, { error: 'Missing id' })
+  }
+
+  const url = process.env.SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE
+  const table = process.env.SUPABASE_EMPLOYEES_TABLE || 'employees'
+  if (!url || !key) {
+    return json(500, { error: 'Supabase not configured' })
+  }
+
+  const res = await fetch(`${url}/rest/v1/${table}?id=eq.${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      Prefer: 'return=minimal'
+    }
+  })
+
+  if (!res.ok) {
+    const detail = await res.text()
+    return json(502, { error: 'Supabase error', detail })
+  }
+
+  return json(200, { ok: true })
+}

--- a/netlify/functions/employees-list.js
+++ b/netlify/functions/employees-list.js
@@ -1,11 +1,11 @@
-const { verifyAdminToken, json } = require('./_auth')
+const { requireAccess, json } = require('./_auth')
 
 exports.handler = async (event) => {
   if (event.httpMethod !== 'GET') {
     return json(405, { error: 'Method Not Allowed' })
   }
   try {
-    verifyAdminToken(event)
+    await requireAccess(event, { allow: ['admin', 'employee'] })
   } catch (e) {
     return json(401, { error: e.message || 'Unauthorized' })
   }

--- a/netlify/functions/employees-list.js
+++ b/netlify/functions/employees-list.js
@@ -1,0 +1,33 @@
+const { verifyAdminToken, json } = require('./_auth')
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'GET') {
+    return json(405, { error: 'Method Not Allowed' })
+  }
+  try {
+    verifyAdminToken(event)
+  } catch (e) {
+    return json(401, { error: e.message || 'Unauthorized' })
+  }
+
+  const url = process.env.SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE
+  const table = process.env.SUPABASE_EMPLOYEES_TABLE || 'employees'
+  if (!url || !key) {
+    return json(200, { items: [] })
+  }
+
+  const params = new URLSearchParams({ select: '*', order: 'last_name.asc', limit: '500' })
+  const res = await fetch(`${url}/rest/v1/${table}?${params}`, {
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`
+    }
+  })
+  if (!res.ok) {
+    const detail = await res.text()
+    return json(502, { error: 'Supabase error', detail })
+  }
+  const data = await res.json()
+  return json(200, { items: data })
+}

--- a/netlify/functions/employees-save.js
+++ b/netlify/functions/employees-save.js
@@ -1,4 +1,4 @@
-const { verifyAdminToken, json } = require('./_auth')
+const { requireAccess, json } = require('./_auth')
 
 const allowedStatuses = new Set(['active', 'on_leave', 'former'])
 
@@ -26,7 +26,7 @@ exports.handler = async (event) => {
     return json(405, { error: 'Method Not Allowed' })
   }
   try {
-    verifyAdminToken(event)
+    await requireAccess(event, { allow: ['admin'] })
   } catch (e) {
     return json(401, { error: e.message || 'Unauthorized' })
   }

--- a/netlify/functions/employees-save.js
+++ b/netlify/functions/employees-save.js
@@ -1,0 +1,100 @@
+const { verifyAdminToken, json } = require('./_auth')
+
+const allowedStatuses = new Set(['active', 'on_leave', 'former'])
+
+function sanitize(value, max = 120) {
+  if (value === null || value === undefined) return ''
+  return String(value).trim().slice(0, max)
+}
+
+function parseDate(value) {
+  if (!value) return null
+  const s = String(value).trim()
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null
+  return s
+}
+
+function parseRate(value) {
+  if (value === null || value === undefined || value === '') return null
+  const num = Number(value)
+  if (!Number.isFinite(num)) return null
+  return Math.round(num * 100) / 100
+}
+
+exports.handler = async (event) => {
+  if (!['POST', 'PUT', 'PATCH'].includes(event.httpMethod)) {
+    return json(405, { error: 'Method Not Allowed' })
+  }
+  try {
+    verifyAdminToken(event)
+  } catch (e) {
+    return json(401, { error: e.message || 'Unauthorized' })
+  }
+
+  let body
+  try {
+    body = JSON.parse(event.body || '{}')
+  } catch (err) {
+    return json(400, { error: 'Invalid JSON' })
+  }
+
+  const firstName = sanitize(body.firstName)
+  const lastName = sanitize(body.lastName)
+  const role = sanitize(body.role)
+  const email = sanitize(body.email, 200).toLowerCase()
+  if (!firstName || !lastName || !role || !email) {
+    return json(400, { error: 'Missing required fields' })
+  }
+
+  const statusRaw = sanitize(body.status, 30).toLowerCase()
+  const status = allowedStatuses.has(statusRaw) ? statusRaw : 'active'
+  const now = new Date().toISOString()
+
+  const record = {
+    first_name: firstName,
+    last_name: lastName,
+    role,
+    email,
+    phone: sanitize(body.phone, 40) || null,
+    status,
+    start_date: parseDate(body.startDate),
+    hourly_rate: parseRate(body.hourlyRate),
+    notes: sanitize(body.notes, 2000) || null,
+    updated_at: now
+  }
+
+  if (!body.id) {
+    record.created_at = now
+  }
+
+  const url = process.env.SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE
+  const table = process.env.SUPABASE_EMPLOYEES_TABLE || 'employees'
+  if (!url || !key) {
+    return json(500, { error: 'Supabase not configured' })
+  }
+
+  const method = body.id ? 'PATCH' : 'POST'
+  const endpoint = body.id
+    ? `${url}/rest/v1/${table}?id=eq.${encodeURIComponent(body.id)}`
+    : `${url}/rest/v1/${table}`
+
+  const res = await fetch(endpoint, {
+    method,
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation'
+    },
+    body: JSON.stringify(record)
+  })
+
+  if (!res.ok) {
+    const detail = await res.text()
+    return json(502, { error: 'Supabase error', detail })
+  }
+
+  const data = await res.json()
+  return json(200, { ok: true, item: Array.isArray(data) ? data[0] : data })
+}

--- a/netlify/functions/quote-update.js
+++ b/netlify/functions/quote-update.js
@@ -2,14 +2,14 @@
 // Env:
 // - ADMIN_EMAILS, SUPABASE_URL, SUPABASE_SERVICE_ROLE, SUPABASE_TABLE
 
-const { verifyAdminToken, json } = require('./_auth')
+const { requireAccess, json } = require('./_auth')
 
 exports.handler = async (event) => {
   if (event.httpMethod !== 'POST' && event.httpMethod !== 'PATCH') {
     return json(405, { error: 'Method Not Allowed' })
   }
   try {
-    verifyAdminToken(event)
+    await requireAccess(event, { allow: ['admin', 'employee'] })
   } catch (e) {
     return json(401, { error: e.message || 'Unauthorized' })
   }

--- a/netlify/functions/quotes-list.js
+++ b/netlify/functions/quotes-list.js
@@ -3,14 +3,15 @@
 // - ADMIN_EMAILS: comma-separated emails allowed to access
 // - SUPABASE_URL, SUPABASE_SERVICE_ROLE, SUPABASE_TABLE (default 'quotes')
 
-const { verifyAdminToken, json } = require('./_auth')
+const { requireAccess, json } = require('./_auth')
 
 exports.handler = async (event) => {
   if (event.httpMethod !== 'GET') {
     return json(405, { error: 'Method Not Allowed' })
   }
+  let access
   try {
-    verifyAdminToken(event)
+    access = await requireAccess(event, { allow: ['admin', 'employee', 'client'] })
   } catch (e) {
     return json(401, { error: e.message || 'Unauthorized' })
   }
@@ -20,8 +21,13 @@ exports.handler = async (event) => {
   const table = process.env.SUPABASE_TABLE || 'quotes'
   if (!url || !key) return json(200, { items: [] })
 
-  const search = new URLSearchParams({ select: '*', order: 'createdAt.desc', limit: '50' })
-  const res = await fetch(`${url}/rest/v1/${table}?${search}`, {
+  const search = new URLSearchParams({ select: '*', order: 'createdAt.desc', limit: '200' })
+  if (access.role === 'client') {
+    search.append('email', `eq.${access.email}`)
+    search.set('limit', '50')
+  }
+
+  const res = await fetch(`${url}/rest/v1/${table}?${search.toString()}`, {
     headers: {
       'apikey': key,
       'Authorization': `Bearer ${key}`

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -11,8 +11,28 @@ const navItems = [
 ]
 
 export default function Navbar() {
-  const { user, login, logout, ready } = useIdentity()
-  const isAuthed = ready && !!user
+  const { user, login, logout, ready, hasDashboardAccess } = useIdentity()
+  const [hasAdminToken, setHasAdminToken] = React.useState(false)
+
+  React.useEffect(() => {
+    function syncToken() {
+      try {
+        const token = localStorage.getItem('vetwraps_admin_token')
+        setHasAdminToken(Boolean(token))
+      } catch {
+        setHasAdminToken(false)
+      }
+    }
+    syncToken()
+    window.addEventListener('storage', syncToken)
+    window.addEventListener('focus', syncToken)
+    return () => {
+      window.removeEventListener('storage', syncToken)
+      window.removeEventListener('focus', syncToken)
+    }
+  }, [])
+
+  const showDashboardLink = hasDashboardAccess || hasAdminToken
 
   return (
     <header className="sticky top-0 z-40 backdrop-blur-md bg-night/70 border-b border-white/5">
@@ -29,7 +49,7 @@ export default function Navbar() {
               {item.label}
             </a>
           ))}
-          {isAuthed ? (
+          {showDashboardLink ? (
             <>
               <Link
                 to="/subscribers"
@@ -37,15 +57,17 @@ export default function Navbar() {
               >
                 Dashboard
               </Link>
-              <button
-                type="button"
-                onClick={logout}
-                className="text-[11px] tracking-[0.2em] uppercase text-white/60 hover:text-white focusable transition-colors"
-              >
-                Log Out
-              </button>
+              {user && (
+                <button
+                  type="button"
+                  onClick={logout}
+                  className="text-[11px] tracking-[0.2em] uppercase text-white/60 hover:text-white focusable transition-colors"
+                >
+                  Log Out
+                </button>
+              )}
             </>
-          ) : (
+          ) : ready ? (
             <button
               type="button"
               onClick={login}
@@ -53,6 +75,9 @@ export default function Navbar() {
             >
               Log In
             </button>
+          ) : null}
+          {!showDashboardLink && !user && !ready && (
+            <span className="text-[11px] tracking-[0.2em] uppercase text-white/60">Loading…</span>
           )}
           <a href="#contact" className="text-[11px] tracking-[0.2em] uppercase bg-white/10 hover:bg-white/20 px-3 py-2 rounded focusable border border-white/10">
             Start Project
@@ -67,20 +92,22 @@ export default function Navbar() {
                   {item.label}
                 </a>
               ))}
-              {isAuthed ? (
+              {showDashboardLink ? (
                 <>
                   <Link to="/subscribers" className="block px-3 py-2 text-sm text-white/85 hover:bg-white/10 rounded">
                     Dashboard
                   </Link>
-                  <button
-                    type="button"
-                    onClick={logout}
-                    className="w-full text-left px-3 py-2 text-sm text-white/70 hover:bg-white/10 rounded"
-                  >
-                    Log Out
-                  </button>
+                  {user && (
+                    <button
+                      type="button"
+                      onClick={logout}
+                      className="w-full text-left px-3 py-2 text-sm text-white/70 hover:bg-white/10 rounded"
+                    >
+                      Log Out
+                    </button>
+                  )}
                 </>
-              ) : (
+              ) : ready ? (
                 <button
                   type="button"
                   onClick={login}
@@ -88,6 +115,8 @@ export default function Navbar() {
                 >
                   Log In
                 </button>
+              ) : (
+                <span className="block px-3 py-2 text-sm text-white/60">Loading…</span>
               )}
               <a href="#contact" className="block px-3 py-2 text-sm text-white/85 hover:bg-white/10 rounded">Start Project</a>
             </div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { useIdentity } from '../utils/identity'
 
 const navItems = [
   { label: 'Services', href: '#services' },
@@ -10,6 +11,9 @@ const navItems = [
 ]
 
 export default function Navbar() {
+  const { user, login, logout, ready } = useIdentity()
+  const isAuthed = ready && !!user
+
   return (
     <header className="sticky top-0 z-40 backdrop-blur-md bg-night/70 border-b border-white/5">
       <nav className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16" aria-label="Primary">
@@ -25,6 +29,31 @@ export default function Navbar() {
               {item.label}
             </a>
           ))}
+          {isAuthed ? (
+            <>
+              <Link
+                to="/subscribers"
+                className="text-[11px] tracking-[0.2em] uppercase text-white/80 hover:text-white focusable transition-colors"
+              >
+                Dashboard
+              </Link>
+              <button
+                type="button"
+                onClick={logout}
+                className="text-[11px] tracking-[0.2em] uppercase text-white/60 hover:text-white focusable transition-colors"
+              >
+                Log Out
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={login}
+              className="text-[11px] tracking-[0.2em] uppercase text-white/70 hover:text-white focusable transition-colors"
+            >
+              Log In
+            </button>
+          )}
           <a href="#contact" className="text-[11px] tracking-[0.2em] uppercase bg-white/10 hover:bg-white/20 px-3 py-2 rounded focusable border border-white/10">
             Start Project
           </a>
@@ -38,6 +67,28 @@ export default function Navbar() {
                   {item.label}
                 </a>
               ))}
+              {isAuthed ? (
+                <>
+                  <Link to="/subscribers" className="block px-3 py-2 text-sm text-white/85 hover:bg-white/10 rounded">
+                    Dashboard
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={logout}
+                    className="w-full text-left px-3 py-2 text-sm text-white/70 hover:bg-white/10 rounded"
+                  >
+                    Log Out
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  onClick={login}
+                  className="w-full text-left px-3 py-2 text-sm text-white/85 hover:bg-white/10 rounded"
+                >
+                  Log In
+                </button>
+              )}
               <a href="#contact" className="block px-3 py-2 text-sm text-white/85 hover:bg-white/10 rounded">Start Project</a>
             </div>
           </details>

--- a/src/components/Testimonials.jsx
+++ b/src/components/Testimonials.jsx
@@ -1,34 +1,26 @@
 import React from 'react'
 
-const data = [
-  { quote: 'Disciplined, sharp, and on time. Our identity finally matches our ambition.', author: 'Operations Lead, Logistics Co.' },
-  { quote: 'Clean and powerful visuals. They listened, iterated, and delivered.', author: 'Marketing Director, Esports Org' },
-  { quote: 'Professional from day one. Streamlined and intentional execution.', author: 'Founder, Creator Studio' }
-]
-
 export default function Testimonials() {
-  const [i, setI] = React.useState(0)
-  React.useEffect(() => {
-    const t = setInterval(() => setI((x) => (x + 1) % data.length), 5000)
-    return () => clearInterval(t)
-  }, [])
   return (
     <section aria-labelledby="testimonials-title" className="py-16">
       <div className="mx-auto max-w-4xl px-4 sm:px-6">
         <h2 id="testimonials-title" className="text-center text-2xl font-semibold">Testimonials</h2>
-        <div className="mt-6 rounded-2xl glass border border-glass p-8 min-h-[160px]">
-          <figure>
-            <blockquote className="text-lg leading-relaxed">“{data[i].quote}”</blockquote>
-            <figcaption className="mt-4 text-sm text-white/70">— {data[i].author}</figcaption>
-          </figure>
-          <div className="mt-6 flex justify-center gap-2">
-            {data.map((_, idx) => (
-              <button key={idx} aria-label={`Go to testimonial ${idx + 1}`} onClick={() => setI(idx)} className={`w-2 h-2 rounded-full ${idx === i ? 'bg-accent-blue' : 'bg-white/20'}`}></button>
-            ))}
+        <div className="mt-6 rounded-2xl glass border border-glass p-8">
+          <p className="text-sm text-white/70 leading-relaxed">
+            We publish testimonials only after clients have formally approved them for public use. As soon as we have permission,
+            you&apos;ll see authentic feedback here. Until then, reach out through the quote form and we&apos;ll connect you directly with
+            references who have opted in.
+          </p>
+          <div className="mt-6 text-center">
+            <a
+              href="#contact"
+              className="inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] bg-white/10 hover:bg-white/20 px-4 py-2 rounded border border-white/10"
+            >
+              Request a Quote
+            </a>
           </div>
         </div>
       </div>
     </section>
   )
 }
-

--- a/src/routes/CaseStudies.jsx
+++ b/src/routes/CaseStudies.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
 
 const cases = [
   { slug: 'precision-esports', title: 'Precision Esports', summary: 'Identity and motion system' },

--- a/src/routes/Subscribers.jsx
+++ b/src/routes/Subscribers.jsx
@@ -21,6 +21,17 @@ const quoteStatusOptions = [
   { value: 'processed', label: 'Processed' }
 ]
 
+const accessRoleOptions = [
+  { value: 'admin', label: 'Admin' },
+  { value: 'employee', label: 'Employee' },
+  { value: 'client', label: 'Client' }
+]
+
+const accessStatusOptions = [
+  { value: 'active', label: 'Active' },
+  { value: 'suspended', label: 'Suspended' }
+]
+
 const emptyEmployeeForm = {
   id: '',
   firstName: '',
@@ -34,9 +45,24 @@ const emptyEmployeeForm = {
   notes: ''
 }
 
+const emptyAccessForm = {
+  id: '',
+  email: '',
+  name: '',
+  role: 'employee',
+  status: 'active',
+  notes: ''
+}
+
 export default function Subscribers() {
-  const { user, ready, login, logout } = useIdentity()
-  const initialToken = React.useMemo(() => localStorage.getItem('vetwraps_admin_token') || '', [])
+  const { user, ready, login, logout, access, refreshAccess } = useIdentity()
+  const initialToken = React.useMemo(() => {
+    try {
+      return localStorage.getItem('vetwraps_admin_token') || ''
+    } catch {
+      return ''
+    }
+  }, [])
   const [storedAdminToken, setStoredAdminToken] = React.useState(initialToken)
   const [adminTokenInput, setAdminTokenInput] = React.useState(initialToken)
 
@@ -57,8 +83,36 @@ export default function Subscribers() {
   const [searchTerm, setSearchTerm] = React.useState('')
   const [loadingQuotes, setLoadingQuotes] = React.useState(false)
 
-  const hasAccess = !!user || !!storedAdminToken
-  const welcomeName = user?.user_metadata?.full_name || user?.email || (storedAdminToken ? 'Admin' : '')
+  const [accessGrants, setAccessGrants] = React.useState([])
+  const [loadingAccessGrants, setLoadingAccessGrants] = React.useState(false)
+  const [accessMessage, setAccessMessage] = React.useState(null)
+  const [accessForm, setAccessForm] = React.useState(emptyAccessForm)
+  const [savingAccess, setSavingAccess] = React.useState(false)
+  const [deletingAccessId, setDeletingAccessId] = React.useState(null)
+  const [updatingAccessId, setUpdatingAccessId] = React.useState(null)
+  const [accessStatusFilter, setAccessStatusFilter] = React.useState('all')
+  const [accessRoleFilter, setAccessRoleFilter] = React.useState('all')
+  const [accessSearch, setAccessSearch] = React.useState('')
+
+  const accessChecked = storedAdminToken ? true : access.checked
+  const hasIdentityAccess = ready && accessChecked && access.allowed
+  const hasAccess = Boolean(storedAdminToken || hasIdentityAccess)
+  const role = storedAdminToken ? 'admin' : access.grant?.role || null
+  const welcomeName =
+    access.grant?.name ||
+    user?.user_metadata?.full_name ||
+    user?.full_name ||
+    user?.email ||
+    (storedAdminToken ? 'Admin' : '')
+  const canViewEmployees = Boolean(storedAdminToken || role === 'admin' || role === 'employee')
+  const canManageEmployees = Boolean(storedAdminToken || role === 'admin')
+  const canViewClients = Boolean(storedAdminToken || role === 'admin' || role === 'employee' || role === 'client')
+  const canManageQuotes = Boolean(storedAdminToken || role === 'admin' || role === 'employee')
+  const canManageAccess = Boolean(storedAdminToken || role === 'admin')
+  const accessReason = access.reason || ''
+  const identityChecking = Boolean(!storedAdminToken && user && ready && (!access.checked || access.loading))
+  const employeeFormDisabled = !canManageEmployees
+  const quotesReadOnly = !canManageQuotes
 
   const loadEmployees = React.useCallback(async () => {
     setEmployeeError(null)
@@ -110,16 +164,64 @@ export default function Subscribers() {
     }
   }, [])
 
+  const loadAccessGrants = React.useCallback(async () => {
+    if (!canManageAccess) return
+    setLoadingAccessGrants(true)
+    try {
+      const res = await authFetch('/api/access-grants-list')
+      let data = {}
+      try {
+        data = await res.json()
+      } catch {
+        data = {}
+      }
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to load access list')
+      }
+      const items = Array.isArray(data.items) ? data.items.map(mapAccessGrant) : []
+      setAccessGrants(items)
+    } catch (err) {
+      setAccessGrants([])
+      setAccessMessage({ type: 'error', text: err.message || 'Failed to load access list' })
+    } finally {
+      setLoadingAccessGrants(false)
+    }
+  }, [canManageAccess])
+
   React.useEffect(() => {
     if (!ready) return
-    if (hasAccess) {
-      loadEmployees()
-      loadQuotes()
-    } else {
+    if (!storedAdminToken && !accessChecked) return
+    if (!hasAccess) {
       setEmployees([])
       setQuotes([])
+      if (!storedAdminToken) setAccessGrants([])
+      return
     }
-  }, [ready, hasAccess, loadEmployees, loadQuotes])
+    if (canViewEmployees) {
+      loadEmployees()
+    } else {
+      setEmployees([])
+    }
+    if (canViewClients) {
+      loadQuotes()
+    } else {
+      setQuotes([])
+    }
+    if (canManageAccess) {
+      loadAccessGrants()
+    }
+  }, [
+    ready,
+    storedAdminToken,
+    accessChecked,
+    hasAccess,
+    canViewEmployees,
+    canViewClients,
+    canManageAccess,
+    loadEmployees,
+    loadQuotes,
+    loadAccessGrants
+  ])
   function handleUseToken() {
     const trimmed = adminTokenInput.trim()
     if (!trimmed) return
@@ -127,6 +229,8 @@ export default function Subscribers() {
     setStoredAdminToken(trimmed)
     setQuotesError(null)
     setEmployeeError(null)
+    setAccessMessage(null)
+    setView((prev) => (prev === 'clients' && !canViewClients ? 'employees' : prev))
   }
 
   function handleClearToken() {
@@ -135,6 +239,152 @@ export default function Subscribers() {
     setAdminTokenInput('')
     setEmployees([])
     setQuotes([])
+    setAccessGrants([])
+    setAccessForm(emptyAccessForm)
+    setAccessMessage(null)
+    refreshAccess()
+  }
+
+  React.useEffect(() => {
+    if (view === 'access' && !canManageAccess) {
+      if (canViewEmployees) setView('employees')
+      else if (canViewClients) setView('clients')
+    } else if (view === 'employees' && !canViewEmployees) {
+      if (canViewClients) setView('clients')
+      else if (canManageAccess) setView('access')
+    } else if (view === 'clients' && !canViewClients) {
+      if (canViewEmployees) setView('employees')
+      else if (canManageAccess) setView('access')
+    }
+  }, [view, canManageAccess, canViewEmployees, canViewClients])
+
+  function handleAccessInputChange(e) {
+    const { name, value } = e.target
+    setAccessForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  function startEditingAccess(grant) {
+    setAccessMessage(null)
+    setAccessForm({
+      id: grant.id || '',
+      email: grant.email || '',
+      name: grant.name || '',
+      role: grant.role || 'client',
+      status: grant.status || 'active',
+      notes: grant.notes || ''
+    })
+  }
+
+  function resetAccessForm() {
+    setAccessForm(emptyAccessForm)
+  }
+
+  async function persistAccess(payload) {
+    const res = await authFetch('/api/access-grants-save', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    let data = {}
+    try {
+      data = await res.json()
+    } catch {
+      data = {}
+    }
+    if (!res.ok) {
+      throw new Error(data.error || 'Failed to save access record')
+    }
+    return data.item
+  }
+
+  async function handleSaveAccess(e) {
+    e.preventDefault()
+    if (!canManageAccess) return
+    const trimmedEmail = accessForm.email.trim().toLowerCase()
+    if (!trimmedEmail) {
+      setAccessMessage({ type: 'error', text: 'Email is required.' })
+      return
+    }
+    setSavingAccess(true)
+    setAccessMessage(null)
+    try {
+      const payload = {
+        id: accessForm.id || undefined,
+        email: trimmedEmail,
+        name: accessForm.name.trim(),
+        role: accessForm.role,
+        status: accessForm.status,
+        notes: accessForm.notes.trim()
+      }
+      await persistAccess(payload)
+      setAccessMessage({ type: 'success', text: accessForm.id ? 'Access updated.' : 'Access granted.' })
+      resetAccessForm()
+      await loadAccessGrants()
+      refreshAccess()
+    } catch (err) {
+      setAccessMessage({ type: 'error', text: err.message || 'Failed to save access record' })
+    } finally {
+      setSavingAccess(false)
+    }
+  }
+
+  async function handleToggleAccessStatus(grant, nextStatus) {
+    if (!canManageAccess) return
+    setAccessMessage(null)
+    setUpdatingAccessId(grant.id)
+    try {
+      await persistAccess({
+        id: grant.id,
+        email: grant.email,
+        name: grant.name || '',
+        role: grant.role || 'client',
+        status: nextStatus,
+        notes: grant.notes || ''
+      })
+      setAccessMessage({
+        type: 'success',
+        text: nextStatus === 'active' ? 'Access reinstated.' : 'Access suspended.'
+      })
+      await loadAccessGrants()
+      refreshAccess()
+    } catch (err) {
+      setAccessMessage({ type: 'error', text: err.message || 'Failed to update access status' })
+    } finally {
+      setUpdatingAccessId(null)
+    }
+  }
+
+  async function handleDeleteAccess(id) {
+    if (!canManageAccess || !id) return
+    if (typeof window !== 'undefined' && !window.confirm('Remove this account?')) return
+    setAccessMessage(null)
+    setDeletingAccessId(id)
+    try {
+      const res = await authFetch('/api/access-grants-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id })
+      })
+      let data = {}
+      try {
+        data = await res.json()
+      } catch {
+        data = {}
+      }
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to remove access')
+      }
+      if (accessForm.id === id) {
+        resetAccessForm()
+      }
+      setAccessMessage({ type: 'success', text: 'Access removed.' })
+      await loadAccessGrants()
+      refreshAccess()
+    } catch (err) {
+      setAccessMessage({ type: 'error', text: err.message || 'Failed to remove access' })
+    } finally {
+      setDeletingAccessId(null)
+    }
   }
 
   function handleEmployeeInputChange(e) {
@@ -165,6 +415,10 @@ export default function Subscribers() {
 
   async function handleSaveEmployee(e) {
     e.preventDefault()
+    if (!canManageEmployees) {
+      setEmployeeMessage({ type: 'error', text: 'Only administrators can modify team members.' })
+      return
+    }
     setEmployeeMessage(null)
     setSavingEmployee(true)
     try {
@@ -183,7 +437,7 @@ export default function Subscribers() {
   }
 
   async function handleDeleteEmployee(id) {
-    if (!id) return
+    if (!id || !canManageEmployees) return
     if (typeof window !== 'undefined' && !window.confirm('Remove this employee?')) return
     setEmployeeMessage(null)
     setDeletingEmployeeId(id)
@@ -216,7 +470,7 @@ export default function Subscribers() {
 
   async function handleStatusChange(id, status) {
     const target = employees.find((emp) => emp.id === id)
-    if (!target) return
+    if (!target || !canManageEmployees) return
     setEmployeeMessage(null)
     setUpdatingStatusId(id)
     try {
@@ -253,12 +507,32 @@ export default function Subscribers() {
   }
 
   async function handleRefreshAll() {
-    await Promise.all([loadEmployees(), loadQuotes()])
+    await Promise.all([
+      canViewEmployees ? loadEmployees() : Promise.resolve(),
+      canViewClients ? loadQuotes() : Promise.resolve(),
+      canManageAccess ? loadAccessGrants() : Promise.resolve()
+    ])
+    if (!storedAdminToken) {
+      refreshAccess()
+    }
   }
   const employeesStats = React.useMemo(() => computeEmployeeStats(employees), [employees])
   const recentHires = React.useMemo(() => computeRecentHires(employees), [employees])
   const anniversaries = React.useMemo(() => computeUpcomingAnniversaries(employees), [employees])
   const clientsStats = React.useMemo(() => computeClientStats(quotes), [quotes])
+  const accessStats = React.useMemo(() => computeAccessStats(accessGrants), [accessGrants])
+  const filteredAccessGrants = React.useMemo(() => {
+    const search = accessSearch.trim().toLowerCase()
+    return accessGrants
+      .filter((item) => (accessStatusFilter === 'all' ? true : item.status === accessStatusFilter))
+      .filter((item) => (accessRoleFilter === 'all' ? true : item.role === accessRoleFilter))
+      .filter((item) => {
+        if (!search) return true
+        return [item.email, item.name, item.notes, item.role]
+          .filter(Boolean)
+          .some((field) => String(field).toLowerCase().includes(search))
+      })
+  }, [accessGrants, accessStatusFilter, accessRoleFilter, accessSearch])
 
   const filteredQuotes = React.useMemo(() => {
     const needle = searchTerm.trim().toLowerCase()
@@ -290,12 +564,18 @@ export default function Subscribers() {
         <title>Operations Dashboard — VetWraps</title>
       </Helmet>
       <div className="mx-auto max-w-6xl px-4 sm:px-6 py-12">
-        {!ready ? (
-          <p className="text-white/70">Loading…</p>
+        {!ready || identityChecking ? (
+          <p className="text-white/70">{identityChecking ? 'Verifying access…' : 'Loading…'}</p>
         ) : !hasAccess ? (
           <div className="text-center">
             <h1 className="text-2xl font-semibold tracking-tight">Restricted</h1>
-            <p className="text-white/70 mt-2 text-sm">Provide an admin token or sign in.</p>
+            {user && !storedAdminToken ? (
+              <p className="text-white/70 mt-2 text-sm">
+                {accessReason || 'Your Google account has not been approved yet.'}
+              </p>
+            ) : (
+              <p className="text-white/70 mt-2 text-sm">Provide an admin token or sign in.</p>
+            )}
             <div className="mt-4 max-w-sm mx-auto space-y-3">
               <input
                 value={adminTokenInput}
@@ -310,13 +590,28 @@ export default function Subscribers() {
                 >
                   Use Token
                 </button>
-                <button
-                  onClick={login}
-                  className="px-4 py-2 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50"
-                >
-                  Sign In
-                </button>
+                {!user ? (
+                  <button
+                    onClick={login}
+                    className="px-4 py-2 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50"
+                  >
+                    Sign In
+                  </button>
+                ) : (
+                  <button
+                    onClick={logout}
+                    className="px-4 py-2 rounded bg-white/10 border border-white/15 hover:border-accent-amber/50"
+                  >
+                    Sign Out
+                  </button>
+                )}
               </div>
+              {user && !storedAdminToken && (
+                <p className="text-xs text-white/50">
+                  Ask an administrator to authorize <span className="font-semibold text-white/70">{user.email}</span> or
+                  provide an admin token.
+                </p>
+              )}
             </div>
           </div>
         ) : (
@@ -327,7 +622,7 @@ export default function Subscribers() {
                 <p className="text-white/70 mt-2 text-sm">Welcome, {welcomeName}.</p>
               </div>
               <div className="flex flex-wrap gap-2">
-                {storedAdminToken && !user && (
+                {storedAdminToken && (
                   <button
                     onClick={handleClearToken}
                     className="px-4 py-2 text-sm rounded bg-white/5 border border-white/10 hover:border-accent-amber/50"
@@ -353,28 +648,44 @@ export default function Subscribers() {
             </div>
 
             <div className="mt-6 flex flex-wrap gap-3">
-              <button
-                onClick={() => setView('employees')}
-                className={`px-4 py-2 text-xs tracking-[0.2em] uppercase rounded border ${
-                  view === 'employees'
-                    ? 'border-accent-blue/60 bg-accent-blue/10'
-                    : 'border-white/10 bg-white/5 hover:border-white/20'
-                }`}
-              >
-                Team
-              </button>
-              <button
-                onClick={() => setView('clients')}
-                className={`px-4 py-2 text-xs tracking-[0.2em] uppercase rounded border ${
-                  view === 'clients'
-                    ? 'border-accent-blue/60 bg-accent-blue/10'
-                    : 'border-white/10 bg-white/5 hover:border-white/20'
-                }`}
-              >
-                Clients
-              </button>
+              {canViewEmployees && (
+                <button
+                  onClick={() => setView('employees')}
+                  className={`px-4 py-2 text-xs tracking-[0.2em] uppercase rounded border ${
+                    view === 'employees'
+                      ? 'border-accent-blue/60 bg-accent-blue/10'
+                      : 'border-white/10 bg-white/5 hover:border-white/20'
+                  }`}
+                >
+                  Team
+                </button>
+              )}
+              {canViewClients && (
+                <button
+                  onClick={() => setView('clients')}
+                  className={`px-4 py-2 text-xs tracking-[0.2em] uppercase rounded border ${
+                    view === 'clients'
+                      ? 'border-accent-blue/60 bg-accent-blue/10'
+                      : 'border-white/10 bg-white/5 hover:border-white/20'
+                  }`}
+                >
+                  Clients
+                </button>
+              )}
+              {canManageAccess && (
+                <button
+                  onClick={() => setView('access')}
+                  className={`px-4 py-2 text-xs tracking-[0.2em] uppercase rounded border ${
+                    view === 'access'
+                      ? 'border-accent-blue/60 bg-accent-blue/10'
+                      : 'border-white/10 bg-white/5 hover:border-white/20'
+                  }`}
+                >
+                  Access
+                </button>
+              )}
             </div>
-            {view === 'employees' ? (
+            {view === 'employees' && canViewEmployees ? (
               <section className="mt-8 space-y-6">
                 <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
                   <StatCard label="Total Staff" value={employeesStats.total} description={`${employeesStats.active} active`} />
@@ -435,7 +746,7 @@ export default function Subscribers() {
                       </button>
                     )}
                   </div>
-                  <div className="mt-4 grid gap-4 md:grid-cols-2">
+                  <fieldset disabled={employeeFormDisabled} className="mt-4 grid gap-4 md:grid-cols-2">
                     <div>
                       <label htmlFor="firstName" className="block text-sm mb-1">First Name</label>
                       <input
@@ -545,11 +856,11 @@ export default function Subscribers() {
                         className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
                       />
                     </div>
-                  </div>
+                  </fieldset>
                   <div className="mt-4 flex items-center gap-3">
                     <button
                       type="submit"
-                      disabled={savingEmployee}
+                      disabled={savingEmployee || employeeFormDisabled}
                       className="px-5 py-2 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50 disabled:opacity-60"
                     >
                       {savingEmployee ? 'Saving…' : employeeForm.id ? 'Update Employee' : 'Add Employee'}
@@ -558,10 +869,14 @@ export default function Subscribers() {
                       type="button"
                       onClick={resetEmployeeForm}
                       className="text-sm text-white/70 hover:text-white"
+                      disabled={employeeFormDisabled}
                     >
                       Reset
                     </button>
                   </div>
+                  {employeeFormDisabled && (
+                    <p className="mt-3 text-sm text-white/60">Only administrators can make staffing changes.</p>
+                  )}
                   {employeeMessage && (
                     <p className={`mt-3 text-sm ${employeeMessage.type === 'error' ? 'text-red-400' : 'text-accent-blue'}`}>
                       {employeeMessage.text}
@@ -609,7 +924,9 @@ export default function Subscribers() {
                                 <select
                                   value={emp.status}
                                   onChange={(e) => handleStatusChange(emp.id, e.target.value)}
-                                  disabled={updatingStatusId === emp.id || deletingEmployeeId === emp.id}
+                                  disabled={
+                                    employeeFormDisabled || updatingStatusId === emp.id || deletingEmployeeId === emp.id
+                                  }
                                   className="bg-white/5 border-white/15 rounded px-2 py-1 text-xs"
                                 >
                                   {employeeStatusOptions.map((opt) => (
@@ -623,13 +940,14 @@ export default function Subscribers() {
                                 <div className="flex flex-wrap gap-2 text-xs">
                                   <button
                                     onClick={() => startEditingEmployee(emp)}
+                                    disabled={employeeFormDisabled}
                                     className="px-2 py-1 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50"
                                   >
                                     Edit
                                   </button>
                                   <button
                                     onClick={() => handleDeleteEmployee(emp.id)}
-                                    disabled={deletingEmployeeId === emp.id}
+                                    disabled={employeeFormDisabled || deletingEmployeeId === emp.id}
                                     className="px-2 py-1 rounded bg-white/10 border border-white/15 hover:border-accent-amber/50 disabled:opacity-60"
                                   >
                                     {deletingEmployeeId === emp.id ? 'Removing…' : 'Remove'}
@@ -644,7 +962,7 @@ export default function Subscribers() {
                   )}
                 </div>
               </section>
-            ) : (
+            ) : view === 'clients' && canViewClients ? (
               <section className="mt-8 space-y-6">
                 <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
                   <StatCard label="Total Requests" value={clientsStats.total} description={`${clientsStats.processed} processed`} />
@@ -696,6 +1014,11 @@ export default function Subscribers() {
                       </button>
                     </div>
                   </div>
+                  {quotesReadOnly && (
+                    <p className="text-xs text-white/60">
+                      Your role allows you to review client submissions without updating their status.
+                    </p>
+                  )}
                   {quoteMessage && (
                     <p className={`text-sm ${quoteMessage.type === 'error' ? 'text-red-400' : 'text-accent-blue'}`}>
                       {quoteMessage.text}
@@ -746,6 +1069,7 @@ export default function Subscribers() {
                                   employees={employees}
                                   onDone={loadQuotes}
                                   onMessage={setQuoteMessage}
+                                  canManage={canManageQuotes}
                                 />
                               </td>
                             </tr>
@@ -755,6 +1079,268 @@ export default function Subscribers() {
                     </div>
                   )}
                 </div>
+              </section>
+            ) : view === 'access' && canManageAccess ? (
+              <section className="mt-8 space-y-6">
+                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                  <StatCard label="Total Accounts" value={accessStats.total} description={`${accessStats.active} active`} />
+                  <StatCard label="Admins" value={accessStats.admins} description={`${accessStats.employees} team / ${accessStats.clients} clients`} />
+                  <StatCard label="Suspended" value={accessStats.suspended} description="Awaiting re-activation" />
+                  <StatCard
+                    label="Last Change"
+                    value={accessStats.lastUpdated ? formatDate(accessStats.lastUpdated) : '—'}
+                    description={accessStats.lastUpdated ? 'Most recent update' : 'No changes recorded'}
+                  />
+                </div>
+
+                <form onSubmit={handleSaveAccess} className="rounded-xl glass border border-glass p-6">
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                    <h2 className="text-lg font-semibold tracking-tight">
+                      {accessForm.id ? 'Update Access' : 'Grant Access'}
+                    </h2>
+                    {accessForm.id && (
+                      <button type="button" onClick={resetAccessForm} className="text-sm text-white/70 hover:text-white">
+                        Cancel edit
+                      </button>
+                    )}
+                  </div>
+                  <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="accessEmail" className="block text-sm mb-1">
+                        Google Email
+                      </label>
+                      <input
+                        id="accessEmail"
+                        name="email"
+                        type="email"
+                        value={accessForm.email}
+                        onChange={handleAccessInputChange}
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                        required
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="accessName" className="block text-sm mb-1">
+                        Name (optional)
+                      </label>
+                      <input
+                        id="accessName"
+                        name="name"
+                        value={accessForm.name}
+                        onChange={handleAccessInputChange}
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="accessRole" className="block text-sm mb-1">
+                        Role
+                      </label>
+                      <select
+                        id="accessRole"
+                        name="role"
+                        value={accessForm.role}
+                        onChange={handleAccessInputChange}
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      >
+                        {accessRoleOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label htmlFor="accessStatus" className="block text-sm mb-1">
+                        Status
+                      </label>
+                      <select
+                        id="accessStatus"
+                        name="status"
+                        value={accessForm.status}
+                        onChange={handleAccessInputChange}
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      >
+                        {accessStatusOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div className="md:col-span-2">
+                      <label htmlFor="accessNotes" className="block text-sm mb-1">
+                        Notes
+                      </label>
+                      <textarea
+                        id="accessNotes"
+                        name="notes"
+                        rows={3}
+                        value={accessForm.notes}
+                        onChange={handleAccessInputChange}
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      />
+                    </div>
+                  </div>
+                  <div className="mt-4 flex items-center gap-3">
+                    <button
+                      type="submit"
+                      disabled={savingAccess}
+                      className="px-5 py-2 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50 disabled:opacity-60"
+                    >
+                      {savingAccess ? 'Saving…' : accessForm.id ? 'Save Changes' : 'Authorize Account'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={resetAccessForm}
+                      className="text-sm text-white/70 hover:text-white"
+                      disabled={savingAccess}
+                    >
+                      Reset
+                    </button>
+                  </div>
+                  {accessMessage && (
+                    <p className={`mt-3 text-sm ${accessMessage.type === 'error' ? 'text-red-400' : 'text-accent-blue'}`}>
+                      {accessMessage.text}
+                    </p>
+                  )}
+                </form>
+
+                <div className="rounded-xl glass border border-glass p-6 space-y-4">
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                    <div className="flex flex-wrap gap-3 items-end">
+                      <label className="text-sm">
+                        <span className="block mb-1 text-white/70">Status</span>
+                        <select
+                          value={accessStatusFilter}
+                          onChange={(e) => setAccessStatusFilter(e.target.value)}
+                          className="bg-white/5 border-white/15 rounded px-3 py-2 text-sm"
+                        >
+                          <option value="all">All</option>
+                          {accessStatusOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="text-sm">
+                        <span className="block mb-1 text-white/70">Role</span>
+                        <select
+                          value={accessRoleFilter}
+                          onChange={(e) => setAccessRoleFilter(e.target.value)}
+                          className="bg-white/5 border-white/15 rounded px-3 py-2 text-sm"
+                        >
+                          <option value="all">All</option>
+                          {accessRoleOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="text-sm">
+                        <span className="block mb-1 text-white/70">Search</span>
+                        <input
+                          value={accessSearch}
+                          onChange={(e) => setAccessSearch(e.target.value)}
+                          placeholder="Email, name, notes…"
+                          className="bg-white/5 border-white/15 rounded px-3 py-2 text-sm min-w-[220px]"
+                        />
+                      </label>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        onClick={() => loadAccessGrants()}
+                        type="button"
+                        className="px-4 py-2 text-sm rounded bg-white/5 border border-white/10 hover:border-accent-blue/50 disabled:opacity-60"
+                        disabled={loadingAccessGrants}
+                      >
+                        Reload
+                      </button>
+                    </div>
+                  </div>
+                  {loadingAccessGrants && <p className="text-sm text-white/60">Loading authorized accounts…</p>}
+                  {accessMessage && accessMessage.type === 'error' && (
+                    <p className="text-sm text-red-400">{accessMessage.text}</p>
+                  )}
+                  {!loadingAccessGrants && filteredAccessGrants.length === 0 ? (
+                    <p className="text-sm text-white/60">No accounts match the current filters.</p>
+                  ) : (
+                    <div className="overflow-x-auto">
+                      <table className="min-w-full text-sm">
+                        <thead className="text-white/60">
+                          <tr>
+                            <th className="text-left py-2 pr-4">Email</th>
+                            <th className="text-left py-2 pr-4">Name</th>
+                            <th className="text-left py-2 pr-4">Role</th>
+                            <th className="text-left py-2 pr-4">Status</th>
+                            <th className="text-left py-2 pr-4">Last Seen</th>
+                            <th className="text-left py-2 pr-4">Notes</th>
+                            <th className="text-left py-2 pr-4">Actions</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {filteredAccessGrants.map((grant) => (
+                            <tr key={grant.id || grant.email} className="border-t border-white/10">
+                              <td className="py-2 pr-4 font-medium break-all">{grant.email}</td>
+                              <td className="py-2 pr-4 text-white/70">{grant.name || '—'}</td>
+                              <td className="py-2 pr-4 text-white/70 capitalize">{grant.role}</td>
+                              <td className="py-2 pr-4">
+                                <span
+                                  className={`inline-flex items-center px-2 py-0.5 rounded text-xs border ${
+                                    grant.status === 'active'
+                                      ? 'border-accent-blue/40 bg-accent-blue/10 text-accent-blue'
+                                      : 'border-accent-amber/40 bg-accent-amber/10 text-accent-amber'
+                                  }`}
+                                >
+                                  {grant.status === 'active' ? 'Active' : 'Suspended'}
+                                </span>
+                              </td>
+                              <td className="py-2 pr-4 text-white/60 text-xs">
+                                {grant.lastSeenAt ? formatDate(grant.lastSeenAt) : '—'}
+                              </td>
+                              <td className="py-2 pr-4 max-w-xs whitespace-pre-wrap break-words text-white/70">{grant.notes || '—'}</td>
+                              <td className="py-2 pr-4">
+                                <div className="flex flex-wrap gap-2 text-xs">
+                                  <button
+                                    type="button"
+                                    onClick={() => startEditingAccess(grant)}
+                                    disabled={updatingAccessId === grant.id || deletingAccessId === grant.id}
+                                    className="px-2 py-1 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50"
+                                  >
+                                    Edit
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => handleToggleAccessStatus(grant, grant.status === 'active' ? 'suspended' : 'active')}
+                                    disabled={updatingAccessId === grant.id || deletingAccessId === grant.id}
+                                    className="px-2 py-1 rounded bg-white/10 border border-white/15 hover:border-accent-amber/50"
+                                  >
+                                    {grant.status === 'active' ? 'Suspend' : 'Activate'}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => handleDeleteAccess(grant.id)}
+                                    disabled={deletingAccessId === grant.id || updatingAccessId === grant.id}
+                                    className="px-2 py-1 rounded bg-white/10 border border-white/15 hover:border-red-400/60 disabled:opacity-60"
+                                  >
+                                    {deletingAccessId === grant.id ? 'Removing…' : 'Remove'}
+                                  </button>
+                                </div>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </div>
+              </section>
+            ) : (
+              <section className="mt-8">
+                <p className="text-sm text-white/60">
+                  Access to this workspace is restricted for your account. Please contact an administrator for assistance.
+                </p>
               </section>
             )}
           </>
@@ -781,6 +1367,21 @@ function mapEmployeeRecord(row) {
   }
 }
 
+function mapAccessGrant(row = {}) {
+  return {
+    id: row.id || null,
+    email: row.email || '',
+    name: row.name || '',
+    role: (row.role || 'client').toLowerCase(),
+    status: (row.status || 'active').toLowerCase(),
+    notes: row.notes || '',
+    createdAt: row.created_at || row.createdAt || null,
+    updatedAt: row.updated_at || row.updatedAt || null,
+    lastSeenAt: row.last_seen_at || row.lastSeenAt || null,
+    lastSeenIp: row.last_seen_ip || row.lastSeenIp || ''
+  }
+}
+
 function prepareEmployeePayload(form) {
   return {
     id: form.id || undefined,
@@ -793,6 +1394,48 @@ function prepareEmployeePayload(form) {
     status: form.status || 'active',
     hourlyRate: form.hourlyRate === null || form.hourlyRate === undefined ? '' : String(form.hourlyRate).trim(),
     notes: (form.notes || '').trim()
+  }
+}
+
+function computeAccessStats(items = []) {
+  if (!items.length) {
+    return {
+      total: 0,
+      active: 0,
+      suspended: 0,
+      admins: 0,
+      employees: 0,
+      clients: 0,
+      lastUpdated: null
+    }
+  }
+  let active = 0
+  let suspended = 0
+  let admins = 0
+  let employeesCount = 0
+  let clientsCount = 0
+  let lastUpdated = null
+  items.forEach((item) => {
+    const status = (item.status || 'active').toLowerCase()
+    if (status === 'active') active += 1
+    else suspended += 1
+    const role = (item.role || 'client').toLowerCase()
+    if (role === 'admin') admins += 1
+    else if (role === 'employee') employeesCount += 1
+    else clientsCount += 1
+    const updated = parseISODate(item.updatedAt || item.updated_at)
+    if (updated && (!lastUpdated || updated > lastUpdated)) {
+      lastUpdated = updated
+    }
+  })
+  return {
+    total: items.length,
+    active,
+    suspended,
+    admins,
+    employees: employeesCount,
+    clients: clientsCount,
+    lastUpdated
   }
 }
 
@@ -1075,8 +1718,12 @@ function escapeCsv(value) {
   return str
 }
 
-function RowActions({ quote, employees, onDone, onMessage }) {
+function RowActions({ quote, employees, onDone, onMessage, canManage = true }) {
   const [busy, setBusy] = React.useState(false)
+
+  if (!canManage) {
+    return <p className="text-xs text-white/50">View only</p>
+  }
 
   async function update(payload) {
     onMessage?.(null)

--- a/src/routes/Subscribers.jsx
+++ b/src/routes/Subscribers.jsx
@@ -3,116 +3,760 @@ import { Helmet } from 'react-helmet-async'
 import { useIdentity } from '../utils/identity'
 import { authFetch } from '../utils/api'
 
+const employeeStatusOptions = [
+  { value: 'active', label: 'Active' },
+  { value: 'on_leave', label: 'On Leave' },
+  { value: 'former', label: 'Former' }
+]
+
+const employeeStatusLabels = employeeStatusOptions.reduce((acc, item) => {
+  acc[item.value] = item.label
+  return acc
+}, {})
+
+const quoteStatusOptions = [
+  { value: 'all', label: 'All' },
+  { value: 'new', label: 'New' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'processed', label: 'Processed' }
+]
+
+const emptyEmployeeForm = {
+  id: '',
+  firstName: '',
+  lastName: '',
+  email: '',
+  role: '',
+  phone: '',
+  startDate: '',
+  status: 'active',
+  hourlyRate: '',
+  notes: ''
+}
+
 export default function Subscribers() {
   const { user, ready, login, logout } = useIdentity()
-  const [adminToken, setAdminToken] = React.useState(() => localStorage.getItem('vetwraps_admin_token') || '')
-  const [items, setItems] = React.useState(null)
-  const [error, setError] = React.useState(null)
-  const [statusFilter, setStatusFilter] = React.useState('all')
+  const initialToken = React.useMemo(() => localStorage.getItem('vetwraps_admin_token') || '', [])
+  const [storedAdminToken, setStoredAdminToken] = React.useState(initialToken)
+  const [adminTokenInput, setAdminTokenInput] = React.useState(initialToken)
 
-  async function load() {
-    setError(null)
-    setItems(null)
+  const [view, setView] = React.useState('employees')
+  const [employees, setEmployees] = React.useState([])
+  const [employeeError, setEmployeeError] = React.useState(null)
+  const [employeeMessage, setEmployeeMessage] = React.useState(null)
+  const [employeeForm, setEmployeeForm] = React.useState(emptyEmployeeForm)
+  const [savingEmployee, setSavingEmployee] = React.useState(false)
+  const [deletingEmployeeId, setDeletingEmployeeId] = React.useState(null)
+  const [updatingStatusId, setUpdatingStatusId] = React.useState(null)
+  const [loadingEmployees, setLoadingEmployees] = React.useState(false)
+
+  const [quotes, setQuotes] = React.useState([])
+  const [quotesError, setQuotesError] = React.useState(null)
+  const [quoteMessage, setQuoteMessage] = React.useState(null)
+  const [statusFilter, setStatusFilter] = React.useState('all')
+  const [searchTerm, setSearchTerm] = React.useState('')
+  const [loadingQuotes, setLoadingQuotes] = React.useState(false)
+
+  const hasAccess = !!user || !!storedAdminToken
+  const welcomeName = user?.user_metadata?.full_name || user?.email || (storedAdminToken ? 'Admin' : '')
+
+  const loadEmployees = React.useCallback(async () => {
+    setEmployeeError(null)
+    setLoadingEmployees(true)
+    try {
+      const res = await authFetch('/api/employees-list')
+      let data = {}
+      try {
+        data = await res.json()
+      } catch {
+        data = {}
+      }
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to load employees')
+      }
+      const items = Array.isArray(data.items) ? data.items.map(mapEmployeeRecord) : []
+      setEmployees(items)
+    } catch (err) {
+      setEmployees([])
+      setEmployeeError(err.message || 'Failed to load employees')
+    } finally {
+      setLoadingEmployees(false)
+    }
+  }, [])
+
+  const loadQuotes = React.useCallback(async () => {
+    setQuotesError(null)
+    setLoadingQuotes(true)
     try {
       const res = await authFetch('/api/quotes-list')
-      if (!res.ok) throw new Error('Failed to load')
-      const data = await res.json()
-      setItems(data.items || [])
-    } catch (e) {
-      setError(e.message || 'Error')
+      let data = {}
+      try {
+        data = await res.json()
+      } catch {
+        data = {}
+      }
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to load clients')
+      }
+      const items = Array.isArray(data.items)
+        ? data.items.map((item) => ({ ...item, status: item.status || 'new' }))
+        : []
+      setQuotes(items)
+    } catch (err) {
+      setQuotes([])
+      setQuotesError(err.message || 'Failed to load clients')
+    } finally {
+      setLoadingQuotes(false)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    if (!ready) return
+    if (hasAccess) {
+      loadEmployees()
+      loadQuotes()
+    } else {
+      setEmployees([])
+      setQuotes([])
+    }
+  }, [ready, hasAccess, loadEmployees, loadQuotes])
+  function handleUseToken() {
+    const trimmed = adminTokenInput.trim()
+    if (!trimmed) return
+    localStorage.setItem('vetwraps_admin_token', trimmed)
+    setStoredAdminToken(trimmed)
+    setQuotesError(null)
+    setEmployeeError(null)
+  }
+
+  function handleClearToken() {
+    localStorage.removeItem('vetwraps_admin_token')
+    setStoredAdminToken('')
+    setAdminTokenInput('')
+    setEmployees([])
+    setQuotes([])
+  }
+
+  function handleEmployeeInputChange(e) {
+    const { name, value } = e.target
+    setEmployeeForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  function startEditingEmployee(emp) {
+    setEmployeeMessage(null)
+    setEmployeeForm({
+      id: emp.id,
+      firstName: emp.firstName,
+      lastName: emp.lastName,
+      email: emp.email,
+      role: emp.role,
+      phone: emp.phone || '',
+      startDate: emp.startDate || '',
+      status: emp.status || 'active',
+      hourlyRate: emp.hourlyRate != null && emp.hourlyRate !== '' ? String(emp.hourlyRate) : '',
+      notes: emp.notes || ''
+    })
+    setView('employees')
+  }
+
+  function resetEmployeeForm() {
+    setEmployeeForm(emptyEmployeeForm)
+  }
+
+  async function handleSaveEmployee(e) {
+    e.preventDefault()
+    setEmployeeMessage(null)
+    setSavingEmployee(true)
+    try {
+      const payload = prepareEmployeePayload(employeeForm)
+      const saved = await persistEmployee(payload)
+      setEmployeeMessage({ type: 'success', text: payload.id ? 'Employee updated.' : 'Employee added.' })
+      resetEmployeeForm()
+      await loadEmployees()
+      return saved
+    } catch (err) {
+      setEmployeeMessage({ type: 'error', text: err.message || 'Failed to save employee' })
+      throw err
+    } finally {
+      setSavingEmployee(false)
     }
   }
 
-  React.useEffect(() => {
-    if (user) load()
-  }, [user])
+  async function handleDeleteEmployee(id) {
+    if (!id) return
+    if (typeof window !== 'undefined' && !window.confirm('Remove this employee?')) return
+    setEmployeeMessage(null)
+    setDeletingEmployeeId(id)
+    try {
+      const res = await authFetch('/api/employees-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id })
+      })
+      let data = {}
+      try {
+        data = await res.json()
+      } catch {
+        data = {}
+      }
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to delete employee')
+      }
+      if (employeeForm.id === id) {
+        resetEmployeeForm()
+      }
+      setEmployeeMessage({ type: 'success', text: 'Employee removed.' })
+      await loadEmployees()
+    } catch (err) {
+      setEmployeeMessage({ type: 'error', text: err.message || 'Failed to delete employee' })
+    } finally {
+      setDeletingEmployeeId(null)
+    }
+  }
+
+  async function handleStatusChange(id, status) {
+    const target = employees.find((emp) => emp.id === id)
+    if (!target) return
+    setEmployeeMessage(null)
+    setUpdatingStatusId(id)
+    try {
+      await persistEmployee(prepareEmployeePayload({ ...target, status }))
+      setEmployeeMessage({ type: 'success', text: `Status updated to ${employeeStatusLabels[status]}` })
+      await loadEmployees()
+    } catch (err) {
+      setEmployeeMessage({ type: 'error', text: err.message || 'Failed to update status' })
+    } finally {
+      setUpdatingStatusId(null)
+    }
+  }
+
+  async function persistEmployee(payload) {
+    const res = await authFetch('/api/employees-save', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    let data = {}
+    try {
+      data = await res.json()
+    } catch {
+      data = {}
+    }
+    if (!res.ok) {
+      throw new Error(data.error || 'Failed to save employee')
+    }
+    return data.item
+  }
+
+  function handleSearchChange(e) {
+    setSearchTerm(e.target.value)
+  }
+
+  async function handleRefreshAll() {
+    await Promise.all([loadEmployees(), loadQuotes()])
+  }
+  const employeesStats = React.useMemo(() => computeEmployeeStats(employees), [employees])
+  const recentHires = React.useMemo(() => computeRecentHires(employees), [employees])
+  const anniversaries = React.useMemo(() => computeUpcomingAnniversaries(employees), [employees])
+  const clientsStats = React.useMemo(() => computeClientStats(quotes), [quotes])
+
+  const filteredQuotes = React.useMemo(() => {
+    const needle = searchTerm.trim().toLowerCase()
+    return quotes.filter((q) => {
+      if (statusFilter !== 'all' && (q.status || 'new') !== statusFilter) {
+        return false
+      }
+      if (!needle) return true
+      const haystack = [
+        q.name,
+        q.email,
+        q.projectType,
+        q.notes,
+        q.ip,
+        q.userAgent,
+        q.assignee
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+      return haystack.includes(needle)
+    })
+  }, [quotes, statusFilter, searchTerm])
+
   return (
     <div className="min-h-screen bg-night text-white">
       <Helmet>
         <meta name="robots" content="noindex, nofollow" />
-        <title>Internal Dashboard — Subscribers</title>
+        <title>Operations Dashboard — VetWraps</title>
       </Helmet>
-      <div className="mx-auto max-w-4xl px-4 sm:px-6 py-12">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 py-12">
         {!ready ? (
           <p className="text-white/70">Loading…</p>
-        ) : (!user && !adminToken) ? (
+        ) : !hasAccess ? (
           <div className="text-center">
             <h1 className="text-2xl font-semibold tracking-tight">Restricted</h1>
             <p className="text-white/70 mt-2 text-sm">Provide an admin token or sign in.</p>
-            <div className="mt-4 max-w-sm mx-auto">
-              <input value={adminToken} onChange={(e)=>setAdminToken(e.target.value)} placeholder="x-admin-token" className="w-full bg-white/5 border-white/15 rounded-md" />
-              <div className="mt-3 flex items-center justify-center gap-3">
-                <button onClick={()=>{ localStorage.setItem('vetwraps_admin_token', adminToken); load() }} className="px-4 py-2 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50">Use Token</button>
-                <button onClick={login} className="px-4 py-2 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50">Sign In</button>
+            <div className="mt-4 max-w-sm mx-auto space-y-3">
+              <input
+                value={adminTokenInput}
+                onChange={(e) => setAdminTokenInput(e.target.value)}
+                placeholder="x-admin-token"
+                className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2 text-sm"
+              />
+              <div className="flex items-center justify-center gap-3">
+                <button
+                  onClick={handleUseToken}
+                  className="px-4 py-2 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50"
+                >
+                  Use Token
+                </button>
+                <button
+                  onClick={login}
+                  className="px-4 py-2 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50"
+                >
+                  Sign In
+                </button>
               </div>
             </div>
           </div>
         ) : (
           <>
-            <div className="flex items-center justify-between">
-              <h1 className="text-2xl font-semibold tracking-tight">Internal Dashboard</h1>
-              <button onClick={logout} className="text-sm text-white/80 hover:text-white">Log out</button>
-            </div>
-            <p className="text-white/70 mt-2 text-sm">Welcome, {user?.user_metadata?.full_name || user.email}</p>
-            <div className="mt-6 rounded-xl glass border border-glass p-6">
-              <div className="flex items-center justify-between">
-                <h2 className="font-semibold">Recent Quotes</h2>
-                <div className="flex items-center gap-3">
-                  <select value={statusFilter} onChange={(e)=>setStatusFilter(e.target.value)} className="bg-white/5 border-white/15 rounded text-sm">
-                    <option value="all">All</option>
-                    <option value="new">New</option>
-                    <option value="in_progress">In Progress</option>
-                    <option value="processed">Processed</option>
-                  </select>
-                  <button onClick={load} className="text-sm text-white/80 hover:text-white">Refresh</button>
-                </div>
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h1 className="text-3xl font-semibold tracking-tight">Operations Dashboard</h1>
+                <p className="text-white/70 mt-2 text-sm">Welcome, {welcomeName}.</p>
               </div>
-              {!items && !error && (
-                <p className="mt-4 text-sm text-white/70">Loading…</p>
-              )}
-              {error && (
-                <p className="mt-4 text-sm text-red-400">{error}</p>
-              )}
-              {items && items.length === 0 && (
-                <p className="mt-4 text-sm text-white/70">No quotes yet.</p>
-              )}
-              {items && items.length > 0 && (
-                <div className="mt-4 overflow-x-auto">
-                  <table className="min-w-full text-sm">
-                    <thead className="text-white/70">
-                      <tr>
-                        <th className="text-left py-2 pr-4">Created</th>
-                        <th className="text-left py-2 pr-4">Name</th>
-                        <th className="text-left py-2 pr-4">Email</th>
-                        <th className="text-left py-2 pr-4">Project</th>
-                        <th className="text-left py-2 pr-4">Rush</th>
-                        <th className="text-left py-2 pr-4">Status</th>
-                        <th className="text-left py-2 pr-4">Assignee</th>
-                        <th className="text-left py-2 pr-4">Actions</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {items
-                        .filter(q=> statusFilter==='all' || (q.status||'new')===statusFilter)
-                        .map((q) => (
-                        <tr key={q.id} className={`border-t border-white/10 ${isDueSoon(q) ? 'bg-accent-amber/5' : ''}`}>
-                          <td className="py-2 pr-4 text-white/70">{formatDate(q.createdAt)}</td>
-                          <td className="py-2 pr-4">{q.name}</td>
-                          <td className="py-2 pr-4 text-white/80">{q.email}</td>
-                          <td className="py-2 pr-4">{q.projectType}</td>
-                          <td className="py-2 pr-4">{q.rush ? 'Yes' : 'No'}</td>
-                          <td className="py-2 pr-4">{statusBadge(q.status || 'new')}</td>
-                          <td className="py-2 pr-4">{q.assignee || '-'}</td>
-                          <td className="py-2 pr-4">
-                            <RowActions id={q.id} onDone={load} />
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              )}
+              <div className="flex flex-wrap gap-2">
+                {storedAdminToken && !user && (
+                  <button
+                    onClick={handleClearToken}
+                    className="px-4 py-2 text-sm rounded bg-white/5 border border-white/10 hover:border-accent-amber/50"
+                  >
+                    Clear Admin Token
+                  </button>
+                )}
+                {user && (
+                  <button
+                    onClick={logout}
+                    className="px-4 py-2 text-sm rounded bg-white/5 border border-white/10 hover:border-accent-blue/50"
+                  >
+                    Log out
+                  </button>
+                )}
+                <button
+                  onClick={handleRefreshAll}
+                  className="px-4 py-2 text-sm rounded bg-white/5 border border-white/10 hover:border-accent-blue/50"
+                >
+                  Refresh
+                </button>
+              </div>
             </div>
+
+            <div className="mt-6 flex flex-wrap gap-3">
+              <button
+                onClick={() => setView('employees')}
+                className={`px-4 py-2 text-xs tracking-[0.2em] uppercase rounded border ${
+                  view === 'employees'
+                    ? 'border-accent-blue/60 bg-accent-blue/10'
+                    : 'border-white/10 bg-white/5 hover:border-white/20'
+                }`}
+              >
+                Team
+              </button>
+              <button
+                onClick={() => setView('clients')}
+                className={`px-4 py-2 text-xs tracking-[0.2em] uppercase rounded border ${
+                  view === 'clients'
+                    ? 'border-accent-blue/60 bg-accent-blue/10'
+                    : 'border-white/10 bg-white/5 hover:border-white/20'
+                }`}
+              >
+                Clients
+              </button>
+            </div>
+            {view === 'employees' ? (
+              <section className="mt-8 space-y-6">
+                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                  <StatCard label="Total Staff" value={employeesStats.total} description={`${employeesStats.active} active`} />
+                  <StatCard label="On Leave" value={employeesStats.onLeave} description={`${employeesStats.former} former`} />
+                  <StatCard label="Avg Tenure" value={employeesStats.avgTenureLabel} description={`${employeesStats.newThisQuarter} hired last 90 days`} />
+                  <StatCard
+                    label="Avg Hourly Rate"
+                    value={employeesStats.avgRateLabel}
+                    description={employeesStats.avgRateLabel === '—' ? 'Add rates to track averages' : 'Based on recorded rates'}
+                  />
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="rounded-xl glass border border-glass p-5">
+                    <h2 className="text-sm font-semibold tracking-wide uppercase text-white/70">Recent hires</h2>
+                    {recentHires.length === 0 ? (
+                      <p className="mt-3 text-sm text-white/60">No recent hires recorded.</p>
+                    ) : (
+                      <ul className="mt-3 space-y-2 text-sm text-white/80">
+                        {recentHires.map((item) => (
+                          <li key={item.id} className="flex items-center justify-between gap-3">
+                            <span>{item.name}</span>
+                            <span className="text-white/50 text-xs">{item.startLabel}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                  <div className="rounded-xl glass border border-glass p-5">
+                    <h2 className="text-sm font-semibold tracking-wide uppercase text-white/70">Upcoming anniversaries</h2>
+                    {anniversaries.length === 0 ? (
+                      <p className="mt-3 text-sm text-white/60">No anniversaries within 60 days.</p>
+                    ) : (
+                      <ul className="mt-3 space-y-2 text-sm text-white/80">
+                        {anniversaries.map((item) => (
+                          <li key={item.id} className="flex items-center justify-between gap-3">
+                            <span>{item.name}</span>
+                            <span className="text-white/50 text-xs">{item.label}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                </div>
+
+                <form onSubmit={handleSaveEmployee} className="rounded-xl glass border border-glass p-6">
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                    <h2 className="text-lg font-semibold tracking-tight">
+                      {employeeForm.id ? 'Update Employee' : 'Add Employee'}
+                    </h2>
+                    {employeeForm.id && (
+                      <button
+                        type="button"
+                        onClick={resetEmployeeForm}
+                        className="text-sm text-white/70 hover:text-white"
+                      >
+                        Cancel edit
+                      </button>
+                    )}
+                  </div>
+                  <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label htmlFor="firstName" className="block text-sm mb-1">First Name</label>
+                      <input
+                        id="firstName"
+                        name="firstName"
+                        value={employeeForm.firstName}
+                        onChange={handleEmployeeInputChange}
+                        required
+                        autoComplete="given-name"
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="lastName" className="block text-sm mb-1">Last Name</label>
+                      <input
+                        id="lastName"
+                        name="lastName"
+                        value={employeeForm.lastName}
+                        onChange={handleEmployeeInputChange}
+                        required
+                        autoComplete="family-name"
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="role" className="block text-sm mb-1">Role</label>
+                      <input
+                        id="role"
+                        name="role"
+                        value={employeeForm.role}
+                        onChange={handleEmployeeInputChange}
+                        required
+                        autoComplete="organization-title"
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="email" className="block text-sm mb-1">Email</label>
+                      <input
+                        id="email"
+                        name="email"
+                        type="email"
+                        value={employeeForm.email}
+                        onChange={handleEmployeeInputChange}
+                        required
+                        autoComplete="email"
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="phone" className="block text-sm mb-1">Phone</label>
+                      <input
+                        id="phone"
+                        name="phone"
+                        value={employeeForm.phone}
+                        onChange={handleEmployeeInputChange}
+                        autoComplete="tel"
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="startDate" className="block text-sm mb-1">Start Date</label>
+                      <input
+                        id="startDate"
+                        name="startDate"
+                        type="date"
+                        value={employeeForm.startDate}
+                        onChange={handleEmployeeInputChange}
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="status" className="block text-sm mb-1">Status</label>
+                      <select
+                        id="status"
+                        name="status"
+                        value={employeeForm.status}
+                        onChange={handleEmployeeInputChange}
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      >
+                        {employeeStatusOptions.map((opt) => (
+                          <option key={opt.value} value={opt.value}>{opt.label}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label htmlFor="hourlyRate" className="block text-sm mb-1">Hourly Rate</label>
+                      <input
+                        id="hourlyRate"
+                        name="hourlyRate"
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={employeeForm.hourlyRate}
+                        onChange={handleEmployeeInputChange}
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      />
+                    </div>
+                    <div className="md:col-span-2">
+                      <label htmlFor="notes" className="block text-sm mb-1">Notes</label>
+                      <textarea
+                        id="notes"
+                        name="notes"
+                        rows={3}
+                        value={employeeForm.notes}
+                        onChange={handleEmployeeInputChange}
+                        className="w-full bg-white/5 border-white/15 rounded-md px-3 py-2"
+                      />
+                    </div>
+                  </div>
+                  <div className="mt-4 flex items-center gap-3">
+                    <button
+                      type="submit"
+                      disabled={savingEmployee}
+                      className="px-5 py-2 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50 disabled:opacity-60"
+                    >
+                      {savingEmployee ? 'Saving…' : employeeForm.id ? 'Update Employee' : 'Add Employee'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={resetEmployeeForm}
+                      className="text-sm text-white/70 hover:text-white"
+                    >
+                      Reset
+                    </button>
+                  </div>
+                  {employeeMessage && (
+                    <p className={`mt-3 text-sm ${employeeMessage.type === 'error' ? 'text-red-400' : 'text-accent-blue'}`}>
+                      {employeeMessage.text}
+                    </p>
+                  )}
+                </form>
+
+                <div className="rounded-xl glass border border-glass p-6">
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                    <h2 className="text-lg font-semibold tracking-tight">Team Directory</h2>
+                    {loadingEmployees && <span className="text-sm text-white/60">Refreshing…</span>}
+                  </div>
+                  {employeeError && (
+                    <p className="mt-3 text-sm text-red-400">{employeeError}</p>
+                  )}
+                  {!loadingEmployees && employees.length === 0 && !employeeError ? (
+                    <p className="mt-3 text-sm text-white/60">No team members recorded yet.</p>
+                  ) : (
+                    <div className="mt-4 overflow-x-auto">
+                      <table className="min-w-full text-sm">
+                        <thead className="text-white/60">
+                          <tr>
+                            <th className="text-left py-2 pr-4">Name</th>
+                            <th className="text-left py-2 pr-4">Role</th>
+                            <th className="text-left py-2 pr-4">Email</th>
+                            <th className="text-left py-2 pr-4">Phone</th>
+                            <th className="text-left py-2 pr-4">Start Date</th>
+                            <th className="text-left py-2 pr-4">Tenure</th>
+                            <th className="text-left py-2 pr-4">Status</th>
+                            <th className="text-left py-2 pr-4">Rate</th>
+                            <th className="text-left py-2 pr-4">Notes</th>
+                            <th className="text-left py-2 pr-4">Actions</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {employees.map((emp) => (
+                            <tr key={emp.id} className="border-t border-white/10">
+                              <td className="py-2 pr-4 font-medium">{emp.firstName} {emp.lastName}</td>
+                              <td className="py-2 pr-4">{emp.role}</td>
+                              <td className="py-2 pr-4 break-all text-white/80">{emp.email}</td>
+                              <td className="py-2 pr-4 text-white/70">{emp.phone || '—'}</td>
+                              <td className="py-2 pr-4 text-white/70">{emp.startDate ? formatDateShort(emp.startDate) : '—'}</td>
+                              <td className="py-2 pr-4 text-white/70">{emp.startDate ? formatTenure(emp.startDate) : '—'}</td>
+                              <td className="py-2 pr-4">
+                                <select
+                                  value={emp.status}
+                                  onChange={(e) => handleStatusChange(emp.id, e.target.value)}
+                                  disabled={updatingStatusId === emp.id || deletingEmployeeId === emp.id}
+                                  className="bg-white/5 border-white/15 rounded px-2 py-1 text-xs"
+                                >
+                                  {employeeStatusOptions.map((opt) => (
+                                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                                  ))}
+                                </select>
+                              </td>
+                              <td className="py-2 pr-4 text-white/70">{emp.hourlyRate != null ? formatCurrency(emp.hourlyRate) : '—'}</td>
+                              <td className="py-2 pr-4 max-w-xs whitespace-pre-wrap break-words text-white/70">{emp.notes || '—'}</td>
+                              <td className="py-2 pr-4">
+                                <div className="flex flex-wrap gap-2 text-xs">
+                                  <button
+                                    onClick={() => startEditingEmployee(emp)}
+                                    className="px-2 py-1 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50"
+                                  >
+                                    Edit
+                                  </button>
+                                  <button
+                                    onClick={() => handleDeleteEmployee(emp.id)}
+                                    disabled={deletingEmployeeId === emp.id}
+                                    className="px-2 py-1 rounded bg-white/10 border border-white/15 hover:border-accent-amber/50 disabled:opacity-60"
+                                  >
+                                    {deletingEmployeeId === emp.id ? 'Removing…' : 'Remove'}
+                                  </button>
+                                </div>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </div>
+              </section>
+            ) : (
+              <section className="mt-8 space-y-6">
+                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                  <StatCard label="Total Requests" value={clientsStats.total} description={`${clientsStats.processed} processed`} />
+                  <StatCard label="Active Pipeline" value={clientsStats.pending} description={`${clientsStats.newCount} new / ${clientsStats.inProgress} in progress`} />
+                  <StatCard label="Rush Jobs" value={clientsStats.rushCount} description={`Value ${clientsStats.rushValueLabel}`} />
+                  <StatCard label="Last Submission" value={clientsStats.lastSubmissionLabel} description={clientsStats.avgAgeLabel} />
+                </div>
+
+                <div className="rounded-xl glass border border-glass p-6 space-y-4">
+                  <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                    <div className="flex flex-wrap gap-3 items-end">
+                      <label className="text-sm">
+                        <span className="block mb-1 text-white/70">Status</span>
+                        <select
+                          value={statusFilter}
+                          onChange={(e) => setStatusFilter(e.target.value)}
+                          className="bg-white/5 border-white/15 rounded px-3 py-2 text-sm"
+                        >
+                          {quoteStatusOptions.map((opt) => (
+                            <option key={opt.value} value={opt.value}>{opt.label}</option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="text-sm">
+                        <span className="block mb-1 text-white/70">Search</span>
+                        <input
+                          value={searchTerm}
+                          onChange={handleSearchChange}
+                          placeholder="Name, email, notes…"
+                          className="bg-white/5 border-white/15 rounded px-3 py-2 text-sm min-w-[220px]"
+                        />
+                      </label>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        onClick={() => exportQuotesToCsv(filteredQuotes)}
+                        type="button"
+                        className="px-4 py-2 text-sm rounded bg-white/5 border border-white/10 hover:border-accent-blue/50"
+                        disabled={filteredQuotes.length === 0}
+                      >
+                        Export CSV
+                      </button>
+                      <button
+                        onClick={loadQuotes}
+                        type="button"
+                        className="px-4 py-2 text-sm rounded bg-white/5 border border-white/10 hover:border-accent-blue/50"
+                      >
+                        Refresh
+                      </button>
+                    </div>
+                  </div>
+                  {quoteMessage && (
+                    <p className={`text-sm ${quoteMessage.type === 'error' ? 'text-red-400' : 'text-accent-blue'}`}>
+                      {quoteMessage.text}
+                    </p>
+                  )}
+                  {quotesError && (
+                    <p className="text-sm text-red-400">{quotesError}</p>
+                  )}
+                  {loadingQuotes && <p className="text-sm text-white/60">Loading latest submissions…</p>}
+                  {!loadingQuotes && filteredQuotes.length === 0 && !quotesError ? (
+                    <p className="text-sm text-white/60">No submissions match the current filters.</p>
+                  ) : (
+                    <div className="overflow-x-auto">
+                      <table className="min-w-full text-sm">
+                        <thead className="text-white/60">
+                          <tr>
+                            <th className="text-left py-2 pr-4">Created</th>
+                            <th className="text-left py-2 pr-4">Name</th>
+                            <th className="text-left py-2 pr-4">Email</th>
+                            <th className="text-left py-2 pr-4">Project</th>
+                            <th className="text-left py-2 pr-4">Rush</th>
+                            <th className="text-left py-2 pr-4">Rush Fee</th>
+                            <th className="text-left py-2 pr-4">Notes</th>
+                            <th className="text-left py-2 pr-4">IP</th>
+                            <th className="text-left py-2 pr-4">User Agent</th>
+                            <th className="text-left py-2 pr-4">Status</th>
+                            <th className="text-left py-2 pr-4">Assignee</th>
+                            <th className="text-left py-2 pr-4">Actions</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {filteredQuotes.map((q) => (
+                            <tr key={q.id} className={`border-t border-white/10 ${isDueSoon(q) ? 'bg-accent-amber/5' : ''}`}>
+                              <td className="py-2 pr-4 text-white/70">{formatDate(q.createdAt)}</td>
+                              <td className="py-2 pr-4 font-medium">{q.name}</td>
+                              <td className="py-2 pr-4 text-white/80 break-all">{q.email}</td>
+                              <td className="py-2 pr-4">{q.projectType}</td>
+                              <td className="py-2 pr-4">{q.rush ? 'Yes' : 'No'}</td>
+                              <td className="py-2 pr-4 text-white/70">{q.amountRush ? formatCurrency(q.amountRush) : '—'}</td>
+                              <td className="py-2 pr-4 max-w-xs whitespace-pre-wrap break-words text-white/70">{q.notes || '—'}</td>
+                              <td className="py-2 pr-4 text-white/60 text-xs break-all">{q.ip || '—'}</td>
+                              <td className="py-2 pr-4 text-white/60 text-xs break-words max-w-xs" title={q.userAgent}>{q.userAgent || '—'}</td>
+                              <td className="py-2 pr-4">{statusBadge(q.status || 'new')}</td>
+                              <td className="py-2 pr-4 text-white/70">{q.assignee || '—'}</td>
+                              <td className="py-2 pr-4">
+                                <RowActions
+                                  quote={q}
+                                  employees={employees}
+                                  onDone={loadQuotes}
+                                  onMessage={setQuoteMessage}
+                                />
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </div>
+              </section>
+            )}
           </>
         )}
       </div>
@@ -120,39 +764,391 @@ export default function Subscribers() {
   )
 }
 
-function formatDate(s) {
-  try { return new Date(s).toLocaleString() } catch { return s }
+function mapEmployeeRecord(row) {
+  return {
+    id: row.id,
+    firstName: row.first_name || '',
+    lastName: row.last_name || '',
+    email: row.email || '',
+    role: row.role || '',
+    phone: row.phone || '',
+    startDate: row.start_date || '',
+    status: row.status || 'active',
+    hourlyRate: row.hourly_rate === null || row.hourly_rate === undefined ? null : Number(row.hourly_rate),
+    notes: row.notes || '',
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  }
+}
+
+function prepareEmployeePayload(form) {
+  return {
+    id: form.id || undefined,
+    firstName: (form.firstName || '').trim(),
+    lastName: (form.lastName || '').trim(),
+    email: (form.email || '').trim(),
+    role: (form.role || '').trim(),
+    phone: (form.phone || '').trim(),
+    startDate: form.startDate || '',
+    status: form.status || 'active',
+    hourlyRate: form.hourlyRate === null || form.hourlyRate === undefined ? '' : String(form.hourlyRate).trim(),
+    notes: (form.notes || '').trim()
+  }
+}
+
+function computeEmployeeStats(items = []) {
+  const total = items.length
+  const active = items.filter((emp) => emp.status === 'active').length
+  const onLeave = items.filter((emp) => emp.status === 'on_leave').length
+  const former = items.filter((emp) => emp.status === 'former').length
+  const starts = items
+    .map((emp) => parseISODate(emp.startDate))
+    .filter(Boolean)
+  const now = Date.now()
+  const dayMs = 24 * 60 * 60 * 1000
+  const avgTenureDays = starts.length
+    ? starts.reduce((acc, date) => acc + (now - date.getTime()) / dayMs, 0) / starts.length
+    : 0
+  const avgTenureLabel = avgTenureDays > 0 ? formatTenureFromDays(avgTenureDays) : '—'
+  const rates = items
+    .map((emp) => Number(emp.hourlyRate))
+    .filter((value) => Number.isFinite(value) && value > 0)
+  const avgRate = rates.length ? rates.reduce((acc, value) => acc + value, 0) / rates.length : null
+  const avgRateLabel = avgRate != null ? formatCurrency(avgRate) : '—'
+  const newThisQuarter = starts.filter((date) => now - date.getTime() <= 90 * dayMs).length
+  return {
+    total,
+    active,
+    onLeave,
+    former,
+    avgTenureLabel,
+    avgRateLabel,
+    avgRate,
+    newThisQuarter
+  }
+}
+
+function computeRecentHires(items = []) {
+  const now = Date.now()
+  const dayMs = 24 * 60 * 60 * 1000
+  return items
+    .map((emp) => {
+      const start = parseISODate(emp.startDate)
+      if (!start) return null
+      const days = (now - start.getTime()) / dayMs
+      if (days > 60) return null
+      return {
+        id: emp.id,
+        name: `${emp.firstName} ${emp.lastName}`.trim(),
+        start,
+        startLabel: formatDateShort(start)
+      }
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.start.getTime() - a.start.getTime())
+}
+
+function computeUpcomingAnniversaries(items = []) {
+  const now = new Date()
+  const horizon = new Date(now.getTime() + 60 * 24 * 60 * 60 * 1000)
+  return items
+    .map((emp) => {
+      const start = parseISODate(emp.startDate)
+      if (!start) return null
+      const next = nextAnniversary(start, now)
+      if (next > horizon) return null
+      const years = Math.max(1, next.getFullYear() - start.getFullYear())
+      return {
+        id: emp.id,
+        name: `${emp.firstName} ${emp.lastName}`.trim(),
+        date: next,
+        years
+      }
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.date.getTime() - b.date.getTime())
+    .map((item) => ({
+      id: item.id,
+      name: item.name,
+      label: `${formatDateShort(item.date)} — ${item.years} yr${item.years === 1 ? '' : 's'}`
+    }))
+}
+
+function computeClientStats(items = []) {
+  if (!items.length) {
+    return {
+      total: 0,
+      newCount: 0,
+      inProgress: 0,
+      processed: 0,
+      pending: 0,
+      rushCount: 0,
+      rushValueLabel: '$0.00',
+      lastSubmissionLabel: '—',
+      avgAgeLabel: 'Pipeline clear'
+    }
+  }
+  let newCount = 0
+  let inProgress = 0
+  let processed = 0
+  let rushCount = 0
+  let rushValue = 0
+  let lastSubmission = null
+  let pendingAgeHours = 0
+  let pendingCount = 0
+  const now = Date.now()
+  const hourMs = 60 * 60 * 1000
+  items.forEach((item) => {
+    const status = item.status || 'new'
+    if (status === 'new') newCount += 1
+    else if (status === 'in_progress') inProgress += 1
+    else if (status === 'processed') processed += 1
+    if (item.rush) rushCount += 1
+    const fee = Number(item.amountRush)
+    if (Number.isFinite(fee) && fee > 0) rushValue += fee
+    const created = parseISODate(item.createdAt)
+    if (created) {
+      if (!lastSubmission || created > lastSubmission) lastSubmission = created
+      if (status !== 'processed') {
+        pendingAgeHours += (now - created.getTime()) / hourMs
+        pendingCount += 1
+      }
+    }
+  })
+  const pending = items.length - processed
+  const lastSubmissionLabel = lastSubmission ? formatDate(lastSubmission) : '—'
+  const avgAgeLabel = pendingCount > 0 ? `Avg age ${formatHours(pendingAgeHours / pendingCount)}` : 'Pipeline clear'
+  return {
+    total: items.length,
+    newCount,
+    inProgress,
+    processed,
+    pending,
+    rushCount,
+    rushValue,
+    rushValueLabel: rushValue > 0 ? formatCurrency(rushValue) : '$0.00',
+    lastSubmissionLabel,
+    avgAgeLabel
+  }
+}
+
+function parseISODate(value) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function nextAnniversary(start, now) {
+  const candidate = new Date(now.getFullYear(), start.getMonth(), start.getDate())
+  if (candidate < now) {
+    return new Date(now.getFullYear() + 1, start.getMonth(), start.getDate())
+  }
+  return candidate
+}
+
+function formatTenure(startDate) {
+  const start = parseISODate(startDate)
+  if (!start) return '—'
+  const now = new Date()
+  const diffDays = (now.getTime() - start.getTime()) / (24 * 60 * 60 * 1000)
+  if (diffDays < 1) return 'New'
+  if (diffDays >= 365) {
+    const years = Math.floor(diffDays / 365)
+    const months = Math.round((diffDays % 365) / 30)
+    return months > 0 ? `${years}y ${months}m` : `${years}y`
+  }
+  if (diffDays >= 30) {
+    const months = Math.floor(diffDays / 30)
+    const days = Math.round(diffDays % 30)
+    return days > 0 ? `${months}m ${days}d` : `${months}m`
+  }
+  return `${Math.round(diffDays)}d`
+}
+
+function formatTenureFromDays(days) {
+  if (!Number.isFinite(days) || days <= 0) return '—'
+  if (days >= 365) {
+    const years = days / 365
+    return `${years >= 10 ? years.toFixed(0) : years.toFixed(1)} yrs`
+  }
+  if (days >= 30) {
+    const months = days / 30
+    return `${months >= 10 ? months.toFixed(0) : months.toFixed(1)} mo`
+  }
+  return `${Math.round(days)} days`
+}
+
+function formatDate(value) {
+  try {
+    const date = parseISODate(value)
+    return date ? date.toLocaleString() : value
+  } catch {
+    return value
+  }
+}
+
+function formatDateShort(value) {
+  try {
+    const date = parseISODate(value)
+    return date ? date.toLocaleDateString() : value
+  } catch {
+    return value
+  }
+}
+
+function formatCurrency(value) {
+  try {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value)
+  } catch {
+    return `$${Number(value || 0).toFixed(2)}`
+  }
+}
+
+function formatHours(hours) {
+  if (!Number.isFinite(hours) || hours <= 0) return '0h'
+  if (hours >= 24) {
+    const days = hours / 24
+    return `${days >= 5 ? days.toFixed(0) : days.toFixed(1)}d`
+  }
+  return `${hours >= 5 ? hours.toFixed(0) : hours.toFixed(1)}h`
+}
+
+function statusBadge(status) {
+  const base = 'inline-flex items-center px-2 py-0.5 rounded text-xs border'
+  if (status === 'processed') {
+    return <span className={`${base} border-white/10 bg-white/10 text-white/80`}>Processed</span>
+  }
+  if (status === 'in_progress') {
+    return <span className={`${base} border-accent-blue/30 bg-accent-blue/10 text-accent-blue`}>In Progress</span>
+  }
+  return <span className={`${base} border-white/10 bg-white/5 text-white/80`}>New</span>
 }
 
 function isDueSoon(q) {
   try {
     const created = new Date(q.createdAt)
     const days = q.rush ? 5.5 : 7.5
-    const due = new Date(created.getTime() + days * 24 * 3600 * 1000)
-    const left = +due - Date.now()
-    return left < 48 * 3600 * 1000
-  } catch { return false }
-}
-
-function statusBadge(s) {
-  const base = 'px-2 py-0.5 rounded text-xs border'
-  if (s === 'processed') return <span className={`${base} border-white/10 bg-white/10 text-white/80`}>Processed</span>
-  if (s === 'in_progress') return <span className={`${base} border-accent-blue/30 bg-accent-blue/10 text-accent-blue`}>In Progress</span>
-  return <span className={`${base} border-white/10 bg-white/5 text-white/80`}>New</span>
-}
-
-function RowActions({ id, onDone }) {
-  async function update(payload) {
-    await authFetch('/api/quote-update', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id, ...payload })
-    })
-    await onDone()
+    const due = new Date(created.getTime() + days * 24 * 60 * 60 * 1000)
+    const left = due.getTime() - Date.now()
+    return left < 48 * 60 * 60 * 1000 && (q.status || 'new') !== 'processed'
+  } catch {
+    return false
   }
+}
+
+function exportQuotesToCsv(items = []) {
+  if (!items.length) return
+  const headers = ['Created At', 'Name', 'Email', 'Project Type', 'Rush', 'Rush Fee', 'Notes', 'IP', 'User Agent', 'Status', 'Assignee']
+  const rows = items.map((item) => [
+    formatDate(item.createdAt),
+    item.name,
+    item.email,
+    item.projectType,
+    item.rush ? 'Yes' : 'No',
+    item.amountRush,
+    item.notes,
+    item.ip,
+    item.userAgent,
+    item.status,
+    item.assignee
+  ])
+  const csv = [headers, ...rows]
+    .map((row) => row.map(escapeCsv).join(','))
+    .join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `vetwraps-clients-${new Date().toISOString().slice(0, 10)}.csv`
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+function escapeCsv(value) {
+  if (value === null || value === undefined) return ''
+  const str = String(value).replace(/[\r\n]+/g, ' ')
+  if (/[",]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+function RowActions({ quote, employees, onDone, onMessage }) {
+  const [busy, setBusy] = React.useState(false)
+
+  async function update(payload) {
+    onMessage?.(null)
+    setBusy(true)
+    try {
+      const res = await authFetch('/api/quote-update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: quote.id, ...payload })
+      })
+      let data = {}
+      try {
+        data = await res.json()
+      } catch {
+        data = {}
+      }
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to update quote')
+      }
+      onMessage?.({ type: 'success', text: 'Quote updated.' })
+      await onDone()
+    } catch (err) {
+      onMessage?.({ type: 'error', text: err.message || 'Failed to update quote' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function handleAssign(e) {
+    update({ assignee: e.target.value })
+  }
+
   return (
-    <div className="flex items-center gap-2 text-xs">
-      <button onClick={()=>update({ status: 'in_progress' })} className="px-2 py-1 rounded bg-white/10 border border-white/10 hover:border-accent-blue/50">In Progress</button>
-      <button onClick={()=>update({ status: 'processed', processedAt: true })} className="px-2 py-1 rounded bg-white/10 border border-white/10 hover:border-accent-amber/50">Processed</button>
+    <div className="space-y-2 text-xs">
+      <select
+        value={quote.assignee || ''}
+        onChange={handleAssign}
+        disabled={busy}
+        className="w-full bg-white/5 border-white/15 rounded px-2 py-1"
+      >
+        <option value="">Unassigned</option>
+        {employees.map((emp) => (
+          <option key={emp.id} value={`${emp.firstName} ${emp.lastName}`.trim()}>
+            {emp.firstName} {emp.lastName}
+          </option>
+        ))}
+      </select>
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={() => update({ status: 'in_progress' })}
+          disabled={busy || quote.status === 'in_progress'}
+          className="px-2 py-1 rounded bg-white/10 border border-white/15 hover:border-accent-blue/50 disabled:opacity-60"
+        >
+          In Progress
+        </button>
+        <button
+          onClick={() => update({ status: 'processed', processedAt: true })}
+          disabled={busy || quote.status === 'processed'}
+          className="px-2 py-1 rounded bg-white/10 border border-white/15 hover:border-accent-amber/50 disabled:opacity-60"
+        >
+          Processed
+        </button>
+      </div>
+    </div>
+  )
+}
+function StatCard({ label, value, description }) {
+  return (
+    <div className="rounded-xl glass border border-glass p-5">
+      <p className="text-xs uppercase tracking-[0.2em] text-white/50">{label}</p>
+      <p className="mt-2 text-2xl font-semibold tracking-tight">{value}</p>
+      {description ? <p className="mt-1 text-sm text-white/60">{description}</p> : null}
     </div>
   )
 }

--- a/src/utils/identity.js
+++ b/src/utils/identity.js
@@ -1,18 +1,34 @@
 import React from 'react'
+import { authFetch } from './api'
+
+const defaultAccess = { checked: false, allowed: false, loading: false, grant: null, reason: '' }
 
 export function useIdentity() {
   const [ready, setReady] = React.useState(false)
   const [user, setUser] = React.useState(null)
+  const [access, setAccess] = React.useState(defaultAccess)
+  const widgetRef = React.useRef(null)
+  const refreshCounter = React.useRef(0)
 
   React.useEffect(() => {
     const widget = window.netlifyIdentity
+    widgetRef.current = widget || null
     if (!widget) {
       setReady(true)
       return
     }
-    const onInit = (u) => { setUser(u); setReady(true) }
-    const onLogin = (u) => setUser(u)
-    const onLogout = () => setUser(null)
+    const onInit = (u) => {
+      setUser(u)
+      setReady(true)
+    }
+    const onLogin = (u) => {
+      setUser(u)
+      widget.close?.()
+    }
+    const onLogout = () => {
+      setUser(null)
+      setAccess(defaultAccess)
+    }
     widget.on('init', onInit)
     widget.on('login', onLogin)
     widget.on('logout', onLogout)
@@ -24,14 +40,73 @@ export function useIdentity() {
     }
   }, [])
 
+  const checkAccess = React.useCallback(async () => {
+    if (!ready || !user) {
+      setAccess((prev) => ({ ...defaultAccess, checked: ready }))
+      return
+    }
+    const currentAttempt = ++refreshCounter.current
+    setAccess((prev) => ({ ...prev, loading: true }))
+    try {
+      const res = await authFetch('/api/access-session')
+      let data = {}
+      try {
+        data = await res.json()
+      } catch {
+        data = {}
+      }
+      if (!res.ok) {
+        throw new Error(data.error || 'Unable to verify access')
+      }
+      if (refreshCounter.current !== currentAttempt) return
+      const allowed = Boolean(data.allowed)
+      setAccess({
+        checked: true,
+        allowed,
+        loading: false,
+        grant: data.grant || null,
+        reason: data.reason || (allowed ? '' : 'Access not granted')
+      })
+      if (!allowed) {
+        widgetRef.current?.logout?.()
+      }
+    } catch (err) {
+      if (refreshCounter.current !== currentAttempt) return
+      setAccess({
+        checked: true,
+        allowed: false,
+        loading: false,
+        grant: null,
+        reason: err.message || 'Unable to verify access'
+      })
+      widgetRef.current?.logout?.()
+    }
+  }, [ready, user])
+
+  React.useEffect(() => {
+    checkAccess()
+  }, [checkAccess])
+
   const login = React.useCallback(() => {
-    window.netlifyIdentity?.open('login')
+    const widget = widgetRef.current
+    if (!widget) return
+    try {
+      widget.open('login')
+    } catch (err) {
+      console.error(err)
+    }
   }, [])
 
   const logout = React.useCallback(() => {
-    window.netlifyIdentity?.logout()
+    widgetRef.current?.logout?.()
   }, [])
 
-  return { ready, user, login, logout }
+  const refreshAccess = React.useCallback(() => {
+    checkAccess()
+  }, [checkAccess])
+
+  const hasDashboardAccess = Boolean(access.allowed && user)
+
+  return { ready, user, login, logout, access, refreshAccess, hasDashboardAccess }
 }
 


### PR DESCRIPTION
## Summary
- add Supabase employees table definition and Netlify functions for listing, saving, and deleting staff records
- overhaul the internal /subscribers dashboard with employee management, statistics, CSV export, and richer client detail views
- remove fabricated testimonials and replace with a permission-based notice; fix missing Helmet import in case studies route

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb0911879c832cbe376d963f4c0790